### PR TITLE
Use pathway ID to extract GO BP term

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -808,6 +808,16 @@ public class BioPaxtoGO {
 						
 						mapped = true;
 					}
+				}
+				if(!mapped && entityStrategy.equals(EntityStrategy.YeastCyc)) {
+					Set<String> metacyc_gos = golego.xref_gos.get("MetaCyc:"+model_id);
+					if(metacyc_gos!=null) {
+						for(String goid : metacyc_gos) {
+							OWLClass go = go_cam.df.getOWLClass(IRI.create(goid));
+							go_cam.addTypeAssertion(pathway_e, go);
+							mapped = true;
+						}
+					}
 				}//no mapping, default to root
 				if(!mapped) {
 					go_cam.addTypeAssertion(pathway_e, GoCAM.bp_class);	


### PR DESCRIPTION
For #159.

Current WIP but safe to merge. Just matches a pathway ID against MetaCyc annotations to GO terms, e.g. `SO4ASSIM-PWY` -> `MetaCyc:SO4ASSIM-PWY` -> `GO:0019379`.