### PR TITLE
Fix dup filename for #188

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/Biopax2GOCmdLine.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/Biopax2GOCmdLine.java
@@ -216,9 +216,7 @@ public class Biopax2GOCmdLine {
 					if(name.contains(".owl")||name.contains("biopax")) { 
 						name = name.replaceAll(".owl", "-");
 						name = name.replaceAll(".xml", "-");
-						String this_output_file_stub = output_file_stub+name;
-						this_output_file_stub = this_output_file_stub.replace("pathway-biopax?type=3&object=","");
-						bp2g.convert(biopax.getAbsolutePath(), this_output_file_stub, base_title, default_contributor, default_provider, tag, test_pathways, blaze, taxa);
+						bp2g.convert(biopax.getAbsolutePath(), output_file_stub, base_title, default_contributor, default_provider, tag, test_pathways, blaze, taxa);
 					}
 				}
 			}else {


### PR DESCRIPTION
This is a bandaid for the file cleaning issues (causing duplicate model IDs) we sometimes have on noctua-dev. #189 is for long-term naming decisions.