### PR TITLE
Extract ChEBI ID for all small molecules

### DIFF
--- a/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
+++ b/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
@@ -1282,4 +1282,28 @@ BP has_part R
 		int n = runQueryAndGetCount(q);
 		assertTrue("Incorrect or complete lack of has_input and has_output given stepDirection for "+reaction_node, n==1);
 	}
+	
+	@Test
+	public final void testReactomeChebiMoleculeIds() {
+		System.out.println("testing ChEBI ID extraction for Reactome small molecules");
+		// Using example pathway "Tetrahydrobiopterin (BH4) synthesis, recycling, salvage and regulation" R-HSA-1474151,
+		// test that ChEBI:17804 is used for input small mol PTHP (R-ALL-1474179) 
+		String pathway = "<http://model.geneontology.org/R-HSA-1474151>";
+		String reaction_node = "<http://model.geneontology.org/R-HSA-1475414>";
+		String input_type = "<http://purl.obolibrary.org/obo/CHEBI_17804>";
+		String q =  
+				" prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> "
+				+ "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> "
+				+ "prefix RO: <http://purl.obolibrary.org/obo/RO_> "
+				+ "prefix BFO: <http://purl.obolibrary.org/obo/BFO_> "
+				+ "SELECT ?component_gp_type  \n" + 
+				"WHERE {\n" + 
+				"  GRAPH "+pathway+"  {  \n" + 
+				"       "+reaction_node+" RO:0002233 ?input_node . \n " +
+				"       ?input_node rdf:type "+input_type +
+				"    }\n" + 
+				"  } \n";
+		int n = runQueryAndGetCount(q);
+		assertTrue("Missing "+reaction_node+" has_input "+input_type+" statement", n==1);
+	}
 }

--- a/exchange/src/test/resources/biopax/tetrahydrobiopterin.owl
+++ b/exchange/src/test/resources/biopax/tetrahydrobiopterin.owl
@@ -1,0 +1,3342 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xml:base="http://www.reactome.org/biopax/83/1474151#">
+  <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="http://www.biopax.org/release/biopax-level3.owl" />
+    <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BioPAX pathway converted from "Tetrahydrobiopterin (BH4) synthesis, recycling, salvage and regulation" in the Reactome database.</rdfs:comment>
+  </owl:Ontology>
+  <bp:Pathway rdf:ID="Pathway1">
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction1" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction2" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction3" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction4" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction5" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction6" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction7" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction8" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction9" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction10" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction11" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction12" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction13" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction14" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction15" />
+    <bp:pathwayComponent rdf:resource="#BiochemicalReaction16" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep7" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep4" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep8" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep15" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep10" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep13" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep14" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep3" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep16" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep1" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep12" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep6" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep5" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep2" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep9" />
+    <bp:pathwayOrder rdf:resource="#PathwayStep11" />
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tetrahydrobiopterin (BH4) synthesis, recycling, salvage and regulation</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref193" />
+    <bp:xref rdf:resource="#UnificationXref194" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tetrahydrobiopterin (BH4) is an essential co-factor for the aromatic amino acid hydroxylases and glycerol ether monooxygenase and it regulates nitric oxide synthase (NOS) activity. Inherited BH4 deficiency leads to hyperphenylalaninemia, and dopamine and neurotransmitter deficiency in the brain. BH4 maintains enzymatic coupling to L-arginine oxidation to produce NO. Oxidation of BH4 to BH2 results in NOS uncoupling, resulting in superoxide (O2.-) formation rather than NO. Superoxide rapidly reacts with NO to produce peroxynitrite which can further uncouple NOS.&lt;br&gt;These reactive oxygen species (superoxide and peroxynitrite) can contribute to increased oxidative stress in the endothelium leading to atherosclerosis and hypertension (Thony et al. 2000, Crabtree and Channon 2011,Schulz et al. 2008, Schmidt and Alp 2007).  The synthesis, recycling and effects of BH4 are shown here. Three enzymes are required for the de novo biosynthesis of BH4 and two enzymes for the recycling of BH4.</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref24" />
+    <bp:xref rdf:resource="#PublicationXref25" />
+    <bp:xref rdf:resource="#PublicationXref26" />
+    <bp:xref rdf:resource="#PublicationXref11" />
+    <bp:xref rdf:resource="#RelationshipXref31" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:Pathway>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction1">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule1" />
+    <bp:left rdf:resource="#SmallMolecule2" />
+    <bp:right rdf:resource="#SmallMolecule3" />
+    <bp:right rdf:resource="#SmallMolecule4" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3.5.4.16</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCH1 reduces GTP to dihydroneopterin triphosphate</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref24" />
+    <bp:xref rdf:resource="#UnificationXref25" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The first and rate-limiting enzyme in tetrahydrobiopterin de novo biosynthesis is GTP cyclohydrolase I (GCH1, GTPCHI). Three different isoforms are produced but only isoform 1 is functionally active (Gütlich et al. 1994). GCH1 is functional as a homodecamer. First, a monomer of GCH1 forms a dimer. Then five dimers arrange into a ring-like structure to form the homodecamer (Nar et al. 1995).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref1" />
+    <bp:xref rdf:resource="#PublicationXref2" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule1">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">H2O</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">water</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29356</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref3" />
+    <bp:xref rdf:resource="#UnificationXref4" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref1" />
+  </bp:SmallMolecule>
+  <bp:CellularLocationVocabulary rdf:ID="CellularLocationVocabulary1">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cytosol</bp:term>
+    <bp:xref rdf:resource="#UnificationXref1" />
+  </bp:CellularLocationVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref1">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0005829</bp:id>
+  </bp:UnificationXref>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference1">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">water [ChEBI:15377]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">water</bp:name>
+    <bp:xref rdf:resource="#UnificationXref2" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref2">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:15377</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref3">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29356</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29356</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref4">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29356</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29356.5</bp:comment>
+  </bp:UnificationXref>
+  <bp:Provenance rdf:ID="Provenance1">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:name>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.reactome.org</bp:comment>
+  </bp:Provenance>
+  <bp:RelationshipXref rdf:ID="RelationshipXref1">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00001</bp:id>
+  </bp:RelationshipXref>
+  <bp:RelationshipTypeVocabulary rdf:ID="RelationshipTypeVocabulary1">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">additional information</bp:term>
+    <bp:xref rdf:resource="#UnificationXref5" />
+  </bp:RelationshipTypeVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref5">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MI:0361</bp:id>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule2">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Guanosine 5'-triphosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP)(4-)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference2" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29438</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref7" />
+    <bp:xref rdf:resource="#UnificationXref8" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref2" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference2">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP(4-) [ChEBI:37565]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP(4-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gtp</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">guanosine 5'-triphosphate(4-)</bp:name>
+    <bp:xref rdf:resource="#UnificationXref6" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref6">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:37565</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref7">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29438</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29438</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref8">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29438</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29438.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref2">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00044</bp:id>
+  </bp:RelationshipXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule3">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DHNTP</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dihydroneopterin trisphosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7,8-dihydroneopterin 3'-triphosphate</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference3" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474124</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref10" />
+    <bp:xref rdf:resource="#UnificationXref11" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference3">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7,8-dihydroneopterin 3'-triphosphate(4-) [ChEBI:58462]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7,8-dihydroneopterin 3'-triphosphate(4-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(2R,3S)-3-(2-amino-4-oxo-3,4,7,8-tetrahydropteridin-6-yl)-2,3-dihydroxypropyl triphosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7,8-dihydroneopterin 3'-triphosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7,8-dihydroneopterin 3'-triphosphate tetracation</bp:name>
+    <bp:xref rdf:resource="#UnificationXref9" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref9">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:58462</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref10">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474124</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474124</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref11">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1474124</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1474124.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule4">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HCOOH</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Formate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">formic acid</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Methanoic acid</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference4" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29460</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref13" />
+    <bp:xref rdf:resource="#UnificationXref14" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref3" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference4">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">formate [ChEBI:15740]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">formate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HCO2 anion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">methanoate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hydrogen carboxylate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aminate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">formylate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">formic acid, ion(1-)</bp:name>
+    <bp:xref rdf:resource="#UnificationXref12" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref12">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:15740</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref13">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29460</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29460</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref14">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29460</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29460.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref3">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00058</bp:id>
+  </bp:RelationshipXref>
+  <bp:Catalysis rdf:ID="Catalysis1">
+    <bp:controller rdf:resource="#Complex1" />
+    <bp:controlled rdf:resource="#BiochemicalReaction1" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref4" />
+    <bp:xref rdf:resource="#RelationshipXref5" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:Complex rdf:ID="Complex1">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCH1 decamer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry2" />
+    <bp:component rdf:resource="#Complex2" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474144</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref21" />
+    <bp:xref rdf:resource="#UnificationXref22" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Complex rdf:ID="Complex2">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCH1 dimer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry1" />
+    <bp:component rdf:resource="#Protein1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474143</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref19" />
+    <bp:xref rdf:resource="#UnificationXref20" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein1">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCH1</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP cyclohydrolase 1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCH1_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference1" />
+    <bp:feature rdf:resource="#FragmentFeature1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474127</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref17" />
+    <bp:xref rdf:resource="#UnificationXref18" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference1">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P30793 GCH1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCH1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DYT5</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCH</bp:name>
+    <bp:xref rdf:resource="#UnificationXref16" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Positively regulates nitric oxide synthesis in umbilical vein endothelial cells (HUVECs). May be involved in dopamine synthesis. May modify pain sensitivity and persistence. Isoform GCH-1 is the functional enzyme, the potential function of the enzymatically inactive isoforms remains unknown.ACTIVITY REGULATION GTP shows a positive allosteric effect, and tetrahydrobiopterin inhibits the enzyme activity. Zinc is required for catalytic activity. Inhibited by Mg(2+).PATHWAY Cofactor biosynthesis; 7,8-dihydroneopterin triphosphate biosynthesis; 7,8-dihydroneopterin triphosphate from GTP: step 1/1.SUBUNIT Toroid-shaped homodecamer, composed of a dimer of pentamers. The inactive isoforms also form decamers and may possibly be incorporated into GCH1 heterodecamers, decreasing enzyme stability and activity. Interacts with AHSA1 and GCHFR/GFRP.TISSUE SPECIFICITY In epidermis, expressed predominantly in basal undifferentiated keratinocytes and in some but not all melanocytes (at protein level).INDUCTION Up-regulated by IFNG/IFN-gamma, TNF, IL1B/interleukin-1 beta, bacterial lipopolysaccharides (LPS) and phenylalanine, and down-regulated by dibutyryl-cAMP, iloprost and 8-bromo-cGMP in HUVEC cells. Up-regulation of GCH1 expression, in turn, stimulates production of tetrahydrobiopterin, with subsequent elevation of endothelial nitric oxide synthase activity. Cytokine-induced GCH1 up-regulation in HUVECs in response to TNF and IFNG/IFN-gamma involves cooperative activation of both the NF-kappa-B and JAK2/STAT pathways. Also up-regulated by hydrogen peroxide in human aorta endothelial cells (HAECs).PTM Phosphorylated by casein kinase II at Ser-81 in HAECs during oscillatory shear stress; phosphorylation at Ser-81 results in increased enzyme activity.SIMILARITY Belongs to the GTP cyclohydrolase I family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:BioSource rdf:ID="BioSource1">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Homo sapiens</bp:name>
+    <bp:xref rdf:resource="#UnificationXref15" />
+  </bp:BioSource>
+  <bp:UnificationXref rdf:ID="UnificationXref15">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCBI Taxonomy</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9606</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref16">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P30793</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature1">
+    <bp:featureLocation rdf:resource="#SequenceInterval1" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval1">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite1" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite2" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite1">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite2">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">250</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref17">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474127</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474127</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref18">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474127</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474127.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry1">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein1" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref19">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474143</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474143</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref20">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474143</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474143.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry2">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">5</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex2" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref21">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474144</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474144</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref22">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474144</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474144.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref4">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0003934</bp:id>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary2" />
+  </bp:RelationshipXref>
+  <bp:RelationshipTypeVocabulary rdf:ID="RelationshipTypeVocabulary2">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene ontology term for cellular function</bp:term>
+    <bp:xref rdf:resource="#UnificationXref23" />
+  </bp:RelationshipTypeVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref23">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MI:0355</bp:id>
+  </bp:UnificationXref>
+  <bp:RelationshipTypeVocabulary rdf:ID="RelationshipTypeVocabulary3">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Same Catalyst Activity</bp:term>
+  </bp:RelationshipTypeVocabulary>
+  <bp:RelationshipXref rdf:ID="RelationshipXref5">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474128</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474128</bp:comment>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary3" />
+  </bp:RelationshipXref>
+  <bp:UnificationXref rdf:ID="UnificationXref24">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474146</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474146</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref25">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474146</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474146.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref1">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7663943</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1995</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Atomic structure of GTP cyclohydrolase I</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nar, H</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Huber, R</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Meining, W</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schmid, C</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Weinkauf, S</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacher, A</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Structure 3:459-66</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref2">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">8068008</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1994</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human GTP cyclohydrolase I: only one out of three cDNA isoforms gives rise to the active enzyme</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gütlich, M</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jaeger, E</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rücknagel, KP</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Werner, T</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rödl, W</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ziegler, I</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacher, A</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biochem J 302:215-21</bp:source>
+  </bp:PublicationXref>
+  <bp:Control rdf:ID="Control1">
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#UnificationXref26" />
+    <bp:xref rdf:resource="#UnificationXref27" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:controller rdf:resource="#SmallMolecule5" />
+    <bp:controlled rdf:resource="#BiochemicalReaction1" />
+  </bp:Control>
+  <bp:UnificationXref rdf:ID="UnificationXref26">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474173</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474173</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref27">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474173</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474173.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule5">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-Phe</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(S)-alpha-amino-beta-phenylpropionic acid</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-phenylalanine zwitterion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-phenylalanine</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference5" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29502</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref29" />
+    <bp:xref rdf:resource="#UnificationXref30" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref6" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference5">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-phenylalanine zwitterion [ChEBI:58095]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-phenylalanine zwitterion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">InChI=1S/C9H11NO2/c10-8(9(11)12)6-7-4-2-1-3-5-7/h1-5,8H,6,10H2,(H,11,12)/t8-/m0/s1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phenylalanine</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-phenylalanine</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C9H11NO2</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">[NH3+][C@@H](Cc1ccccc1)C([O-])=O</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(2S)-2-azaniumyl-3-phenylpropanoate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(2S)-2-ammonio-3-phenylpropanoate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">165.18910</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COLNVLDHVKWLRT-QMMMGPOBSA-N</bp:name>
+    <bp:xref rdf:resource="#UnificationXref28" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref28">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:58095</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref29">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29502</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29502</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref30">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29502</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29502.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref6">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00079</bp:id>
+  </bp:RelationshipXref>
+  <bp:Control rdf:ID="Control2">
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">INHIBITION</bp:controlType>
+    <bp:xref rdf:resource="#UnificationXref31" />
+    <bp:xref rdf:resource="#UnificationXref32" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:controller rdf:resource="#SmallMolecule6" />
+    <bp:controlled rdf:resource="#BiochemicalReaction1" />
+  </bp:Control>
+  <bp:UnificationXref rdf:ID="UnificationXref31">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474156</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474156</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref32">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474156</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474156.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule6">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH4</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tetrahydrobiopterin</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5,6,7,8-tetrahydrobiopterin</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2-Amino-6-(1,2-dihydroxypropyl)-5,6,7,8-tetrahydoro-4(1H)-pteridinone</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference6" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29870</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref34" />
+    <bp:xref rdf:resource="#UnificationXref35" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref7" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference6">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5,6,7,8-tetrahydrobiopterin [ChEBI:15372]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5,6,7,8-tetrahydrobiopterin</bp:name>
+    <bp:xref rdf:resource="#UnificationXref33" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref33">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:15372</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref34">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29870</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29870</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref35">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29870</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29870.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref7">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00272</bp:id>
+  </bp:RelationshipXref>
+  <bp:Control rdf:ID="Control3">
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">INHIBITION</bp:controlType>
+    <bp:xref rdf:resource="#UnificationXref36" />
+    <bp:xref rdf:resource="#UnificationXref37" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:controller rdf:resource="#Complex3" />
+    <bp:controlled rdf:resource="#BiochemicalReaction1" />
+  </bp:Control>
+  <bp:UnificationXref rdf:ID="UnificationXref36">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474118</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474118</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref37">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474118</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474118.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Complex rdf:ID="Complex3">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2GCHFR:GCH1</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry4" />
+    <bp:component rdf:resource="#Complex4" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry5" />
+    <bp:component rdf:resource="#Complex1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474149</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref43" />
+    <bp:xref rdf:resource="#UnificationXref44" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Complex rdf:ID="Complex4">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCHFR pentamer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry3" />
+    <bp:component rdf:resource="#Protein2" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474155</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref41" />
+    <bp:xref rdf:resource="#UnificationXref42" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein2">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCHFR</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP cyclohydrolase 1 feedback regulatory protein</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GFRP_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference2" />
+    <bp:feature rdf:resource="#FragmentFeature2" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474159</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref39" />
+    <bp:xref rdf:resource="#UnificationXref40" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference2">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P30047 GCHFR</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCHFR</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GFRP</bp:name>
+    <bp:xref rdf:resource="#UnificationXref38" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Mediates tetrahydrobiopterin inhibition of GTP cyclohydrolase 1. This inhibition is reversed by L-phenylalanine.SUBUNIT Homopentamer. Forms a complex with GCH1 where a GCH1 homodecamer is sandwiched by two GFRP homopentamers (By similarity). Interacts with GCH1.TISSUE SPECIFICITY In epidermis, expressed predominantly in basal undifferentiated keratinocytes and in some but not all melanocytes (at protein level).SIMILARITY Belongs to the GFRP family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref38">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P30047</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature2">
+    <bp:featureLocation rdf:resource="#SequenceInterval2" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval2">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite3" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite4" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite3">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite4">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">84</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref39">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474159</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474159</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref40">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474159</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474159.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry3">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">5</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein2" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref41">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474155</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474155</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref42">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474155</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474155.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry4">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex4" />
+  </bp:Stoichiometry>
+  <bp:Stoichiometry rdf:ID="Stoichiometry5">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex1" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref43">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474149</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474149</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref44">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474149</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474149.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep1">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction1" />
+    <bp:nextStep rdf:resource="#PathwayStep3" />
+    <bp:stepProcess rdf:resource="#Catalysis1" />
+    <bp:stepProcess rdf:resource="#Control1" />
+    <bp:stepProcess rdf:resource="#Control2" />
+    <bp:stepProcess rdf:resource="#Control3" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction2">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:participantStoichiometry rdf:resource="#Stoichiometry6" />
+    <bp:left rdf:resource="#SmallMolecule7" />
+    <bp:left rdf:resource="#Complex5" />
+    <bp:participantStoichiometry rdf:resource="#Stoichiometry8" />
+    <bp:right rdf:resource="#SmallMolecule8" />
+    <bp:right rdf:resource="#Complex6" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2.7.11.12</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTPS is phosphorylated by cGMP-dependant protein kinase II</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref67" />
+    <bp:xref rdf:resource="#UnificationXref68" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6-pyruvoyl tetrahydrobiopterin synthase (PTPS)  requires phosphorylation on Ser-19 for enzyme activity (Scherer-Oppliger et al. 1999).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref3" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule7">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ATP</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenosine 5'-triphosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ATP(4-)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference7" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 113592</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref46" />
+    <bp:xref rdf:resource="#UnificationXref47" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref8" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference7">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ATP(4-) [ChEBI:30616]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ATP(4-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ATP</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atp</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenosine 5'-triphosphate</bp:name>
+    <bp:xref rdf:resource="#UnificationXref45" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref45">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:30616</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref46">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">113592</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=113592</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref47">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-113592</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-113592.5</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref8">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00002</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry6">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">6</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule7" />
+  </bp:Stoichiometry>
+  <bp:Complex rdf:ID="Complex5">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTPS hexamer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry7" />
+    <bp:component rdf:resource="#Protein3" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497879</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref51" />
+    <bp:xref rdf:resource="#UnificationXref52" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein3">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTS</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTPS</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6-pyruvoyl tetrahydrobiopterin synthase</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTPS_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference3" />
+    <bp:feature rdf:resource="#FragmentFeature3" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1475061</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref49" />
+    <bp:xref rdf:resource="#UnificationXref50" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference3">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:Q03393 PTS</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTS</bp:name>
+    <bp:xref rdf:resource="#UnificationXref48" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Involved in the biosynthesis of tetrahydrobiopterin, an essential cofactor of aromatic amino acid hydroxylases. Catalyzes the transformation of 7,8-dihydroneopterin triphosphate into 6-pyruvoyl tetrahydropterin.PATHWAY Cofactor biosynthesis; tetrahydrobiopterin biosynthesis; tetrahydrobiopterin from 7,8-dihydroneopterin triphosphate: step 1/3.SUBUNIT Homohexamer formed of two homotrimers in a head to head fashion.PTM Phosphorylation of Ser-19 is required for maximal enzyme activity.MISCELLANEOUS The active site is at the interface between 2 subunits. The proton acceptor Cys is on one subunit, and the charge relay system is on the other subunit.SIMILARITY Belongs to the PTPS family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref48">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Q03393</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature3">
+    <bp:featureLocation rdf:resource="#SequenceInterval3" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval3">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite5" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite6" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite5">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite6">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">145</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref49">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475061</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475061</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref50">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1475061</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1475061.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry7">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">6</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein3" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref51">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497879</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497879</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref52">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497879</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497879.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule8">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADP</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenosine 5'-diphosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADP(3-)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference8" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29370</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref54" />
+    <bp:xref rdf:resource="#UnificationXref55" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref9" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference8">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADP(3-) [ChEBI:456216]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADP(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADP</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5&amp;apos;-O-[(phosphonatooxy)phosphinato]adenosine</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADP trianion</bp:name>
+    <bp:xref rdf:resource="#UnificationXref53" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref53">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:456216</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref54">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29370</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29370</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref55">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29370</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29370.5</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref9">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00008</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry8">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">6</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule8" />
+  </bp:Stoichiometry>
+  <bp:Complex rdf:ID="Complex6">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-PTPS hexamer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry9" />
+    <bp:component rdf:resource="#Protein4" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry10" />
+    <bp:component rdf:resource="#SmallMolecule9" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1475058</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref62" />
+    <bp:xref rdf:resource="#UnificationXref63" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein4">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTS</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S19-PTS</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S19-PTPS</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6-pyruvoyl tetrahydrobiopterin synthase</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTPS_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference3" />
+    <bp:feature rdf:resource="#ModificationFeature1" />
+    <bp:feature rdf:resource="#FragmentFeature4" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1475426</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref57" />
+    <bp:xref rdf:resource="#UnificationXref58" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ModificationFeature rdf:ID="ModificationFeature1">
+    <bp:featureLocation rdf:resource="#SequenceSite7" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary1" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite7">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">19</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceModificationVocabulary rdf:ID="SequenceModificationVocabulary1">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O-phospho-L-serine</bp:term>
+    <bp:xref rdf:resource="#UnificationXref56" />
+  </bp:SequenceModificationVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref56">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD:00046</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature4">
+    <bp:featureLocation rdf:resource="#SequenceInterval4" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval4">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite8" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite9" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite8">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite9">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">145</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref57">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475426</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475426</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref58">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1475426</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1475426.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry9">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">6</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein4" />
+  </bp:Stoichiometry>
+  <bp:SmallMolecule rdf:ID="SmallMolecule9">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zn2+</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zn++</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc(2+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zinc ion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zn(II)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference9" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29426</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref60" />
+    <bp:xref rdf:resource="#UnificationXref61" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref10" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference9">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc(2+) [ChEBI:29105]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc(2+)</bp:name>
+    <bp:xref rdf:resource="#UnificationXref59" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref59">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:29105</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref60">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29426</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29426</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref61">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29426</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29426.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref10">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00038</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry10">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">6</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule9" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref62">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475058</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475058</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref63">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1475058</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1475058.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Catalysis rdf:ID="Catalysis2">
+    <bp:controller rdf:resource="#Protein5" />
+    <bp:controlled rdf:resource="#BiochemicalReaction2" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref11" />
+    <bp:xref rdf:resource="#RelationshipXref12" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:Protein rdf:ID="Protein5">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PRKG2</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cGMP-dependent protein kinase 2</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KGP2_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference4" />
+    <bp:feature rdf:resource="#FragmentFeature5" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 418377</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref65" />
+    <bp:xref rdf:resource="#UnificationXref66" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference4">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:Q13237 PRKG2</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PRKG2</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PRKGR2</bp:name>
+    <bp:xref rdf:resource="#UnificationXref64" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Crucial regulator of intestinal secretion and bone growth. Phosphorylates and activates CFTR on the plasma membrane. Plays a key role in intestinal secretion by regulating cGMP-dependent translocation of CFTR in jejunum (PubMed:33106379). Acts downstream of NMDAR to activate the plasma membrane accumulation of GRIA1/GLUR1 in synapse and increase synaptic plasticity. Phosphorylates GRIA1/GLUR1 at Ser-863 (By similarity). Acts as regulator of gene expression and activator of the extracellular signal-regulated kinases MAPK3/ERK1 and MAPK1/ERK2 in mechanically stimulated osteoblasts. Under fluid shear stress, mediates ERK activation and subsequent induction of FOS, FOSL1/FRA1, FOSL2/FRA2 and FOSB that play a key role in the osteoblast anabolic response to mechanical stimulation (By similarity).ACTIVITY REGULATION Binding of cGMP results in enzyme activation.SUBUNIT Interacts with GRIA1/GLUR1.TISSUE SPECIFICITY Highly concentrated in brain, lung and intestinal mucosa.PTM Myristoylation mediates membrane localization.SIMILARITY Belongs to the protein kinase superfamily. AGC Ser/Thr protein kinase family. cGMP subfamily.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref64">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Q13237</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature5">
+    <bp:featureLocation rdf:resource="#SequenceInterval5" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval5">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite10" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite11" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite10">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite11">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">762</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref65">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">418377</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=418377</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref66">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-418377</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-418377.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref11">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0004692</bp:id>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary2" />
+  </bp:RelationshipXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref12">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475413</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475413</bp:comment>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary3" />
+  </bp:RelationshipXref>
+  <bp:UnificationXref rdf:ID="UnificationXref67">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475422</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475422</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref68">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1475422</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1475422.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref3">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10531334</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1999</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Serine 19 of human 6-pyruvoyltetrahydropterin synthase is phosphorylated by cGMP protein kinase II</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scherer-Oppliger, T</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leimbacher, W</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Blau, N</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thöny, B</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Biol Chem 274:31341-8</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep2">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction2" />
+    <bp:nextStep rdf:resource="#PathwayStep3" />
+    <bp:stepProcess rdf:resource="#Catalysis2" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction3">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule3" />
+    <bp:right rdf:resource="#SmallMolecule10" />
+    <bp:right rdf:resource="#SmallMolecule11" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4.2.3.12</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DHNTP is dephosphorylated by PTPS to PTHP</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref75" />
+    <bp:xref rdf:resource="#UnificationXref76" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6-pyruvoyl tetrahydrobiopterin synthase (PTPS) (Takikawa et al. 1986) catalyses the second step in BH4 biosynthesis, the dephosphorylation of DHNTP to 6-pyruvoyl-tetrahydropterin (PTHP). PTPS is believed to function as a homohexamer (Nar et al. 1994, Bürgisser et al. 1994) and has a requirement for Zn2+ (one Zn2+ ion bound per subunit) and Mg2+ ions for activity (Bürgisser et al. 1995). The phosphorylation of Ser-19 is an essential modification for enzyme activity (Scherer-Oppliger et al. 1999).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref4" />
+    <bp:xref rdf:resource="#PublicationXref5" />
+    <bp:xref rdf:resource="#PublicationXref3" />
+    <bp:xref rdf:resource="#PublicationXref6" />
+    <bp:xref rdf:resource="#PublicationXref7" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule10">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPP</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">triphosphate ion</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference10" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1475054</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref70" />
+    <bp:xref rdf:resource="#UnificationXref71" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference10">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">triphosphate ion [ChEBI:15266]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">triphosphate ion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Triphosphat</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">triphosphate ions</bp:name>
+    <bp:xref rdf:resource="#UnificationXref69" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref69">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:15266</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref70">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475054</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475054</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref71">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1475054</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1475054.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule11">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTHP</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6-pyruvoyl-tetrahydropterin</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dyspropterin</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference11" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1474179</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref73" />
+    <bp:xref rdf:resource="#UnificationXref74" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference11">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dyspropterin [ChEBI:17804]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dyspropterin</bp:name>
+    <bp:xref rdf:resource="#UnificationXref72" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref72">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:17804</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref73">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474179</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474179</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref74">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1474179</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1474179.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:Catalysis rdf:ID="Catalysis3">
+    <bp:controller rdf:resource="#Complex6" />
+    <bp:controlled rdf:resource="#BiochemicalReaction3" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref13" />
+    <bp:xref rdf:resource="#RelationshipXref14" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:RelationshipXref rdf:ID="RelationshipXref13">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0003874</bp:id>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary2" />
+  </bp:RelationshipXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref14">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475060</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475060</bp:comment>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary3" />
+  </bp:RelationshipXref>
+  <bp:UnificationXref rdf:ID="UnificationXref75">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474184</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474184</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref76">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474184</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474184.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref4">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3536512</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1986</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biosynthesis of tetrahydrobiopterin. Purification and characterization of 6-pyruvoyl-tetrahydropterin synthase from human liver</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Takikawa, S</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Curtius, HC</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Redweik, U</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leimbacher, W</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ghisla, S</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eur J Biochem 161:295-302</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref5">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7563095</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1995</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6-Pyruvoyl tetrahydropterin synthase, an enzyme with a novel type of active site involving both zinc binding and an intersubunit catalytic triad motif; site-directed mutagenesis of the proposed active center, characterization of the metal binding site and modelling of substrate binding</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bürgisser, DM</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thöny, B</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Redweik, U</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hess, D</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heizmann, CW</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Huber, R</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nar, H</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Mol Biol 253:358-69</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref6">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">8137809</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1994</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Three-dimensional structure of 6-pyruvoyl tetrahydropterin synthase, an enzyme involved in tetrahydrobiopterin biosynthesis</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nar, H</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Huber, R</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heizmann, CW</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thöny, B</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bürgisser, D</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMBO J 13:1255-62</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref7">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">8307017</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1994</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Expression and characterization of recombinant human and rat liver 6-pyruvoyl tetrahydropterin synthase. Modified cysteine residues inhibit the enzyme activity</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bürgisser, DM</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thöny, B</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Redweik, U</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hunziker, P</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heizmann, CW</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Blau, N</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eur J Biochem 219:497-502</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep3">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction3" />
+    <bp:nextStep rdf:resource="#PathwayStep5" />
+    <bp:stepProcess rdf:resource="#Catalysis3" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction4">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:participantStoichiometry rdf:resource="#Stoichiometry11" />
+    <bp:left rdf:resource="#SmallMolecule7" />
+    <bp:left rdf:resource="#Complex7" />
+    <bp:participantStoichiometry rdf:resource="#Stoichiometry13" />
+    <bp:right rdf:resource="#SmallMolecule8" />
+    <bp:right rdf:resource="#Complex8" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2.7.11.12</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sepiapterin reductase (SPR) is phosphorylated by Ca2+/calmodulin-dependent protein kinase II</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref86" />
+    <bp:xref rdf:resource="#UnificationXref87" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">To become active, sepiapterin reductase (SPR) must first be phosphorylated (serine 213 in humans) by Ca2+/calmodulin-dependent protein kinase II (Fujimoto et al. 2002, Katoh et al. 1994).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref8" />
+    <bp:xref rdf:resource="#PublicationXref9" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:Stoichiometry rdf:ID="Stoichiometry11">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule7" />
+  </bp:Stoichiometry>
+  <bp:Complex rdf:ID="Complex7">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPR dimer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry12" />
+    <bp:component rdf:resource="#Protein6" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497791</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref80" />
+    <bp:xref rdf:resource="#UnificationXref81" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein6">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPR</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sepiapterin reductase</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPRE_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference5" />
+    <bp:feature rdf:resource="#FragmentFeature6" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497798</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref78" />
+    <bp:xref rdf:resource="#UnificationXref79" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference5">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P35270 SPR</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPR</bp:name>
+    <bp:xref rdf:resource="#UnificationXref77" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Catalyzes the final one or two reductions in tetra-hydrobiopterin biosynthesis to form 5,6,7,8-tetrahydrobiopterin.SUBUNIT Homodimer.PTM In vitro phosphorylation of Ser-213 by CaMK2 does not change kinetic parameters.SIMILARITY Belongs to the sepiapterin reductase family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref77">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P35270</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature6">
+    <bp:featureLocation rdf:resource="#SequenceInterval6" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval6">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite12" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite13" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite12">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite13">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">261</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref78">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497798</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497798</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref79">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497798</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497798.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry12">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein6" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref80">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497791</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497791</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref81">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497791</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497791.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry13">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule8" />
+  </bp:Stoichiometry>
+  <bp:Complex rdf:ID="Complex8">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-SPR dimer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry14" />
+    <bp:component rdf:resource="#Protein7" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497817</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref84" />
+    <bp:xref rdf:resource="#UnificationXref85" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein7">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPR</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S213-SPR</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sepiapterin reductase</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPRE_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference5" />
+    <bp:feature rdf:resource="#ModificationFeature2" />
+    <bp:feature rdf:resource="#FragmentFeature7" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497782</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref82" />
+    <bp:xref rdf:resource="#UnificationXref83" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ModificationFeature rdf:ID="ModificationFeature2">
+    <bp:featureLocation rdf:resource="#SequenceSite14" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary1" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite14">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">213</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:FragmentFeature rdf:ID="FragmentFeature7">
+    <bp:featureLocation rdf:resource="#SequenceInterval7" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval7">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite15" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite16" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite15">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite16">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">261</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref82">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497782</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497782</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref83">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497782</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497782.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry14">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein7" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref84">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497817</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497817</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref85">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497817</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497817.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Catalysis rdf:ID="Catalysis4">
+    <bp:controller rdf:resource="#Protein5" />
+    <bp:controlled rdf:resource="#BiochemicalReaction4" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref11" />
+    <bp:xref rdf:resource="#RelationshipXref12" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:UnificationXref rdf:ID="UnificationXref86">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497853</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497853</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref87">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497853</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497853.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref8">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">8137944</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1994</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phosphorylation by Ca2+/calmodulin-dependent protein kinase II and protein kinase C of sepiapterin reductase, the terminal enzyme in the biosynthetic pathway of tetrahydrobiopterin</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Katoh, S</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sueoka, T</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yamamoto, Y</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Takahashi, SY</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FEBS Lett 341:227-32</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref9">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">11825621</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2002</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mutational analysis of sites in sepiapterin reductase phosphorylated by Ca2+/calmodulin-dependent protein kinase II</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fujimoto, K</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Takahashi, SY</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Katoh, S</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biochim Biophys Acta 1594:191-8</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep4">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction4" />
+    <bp:nextStep rdf:resource="#PathwayStep5" />
+    <bp:stepProcess rdf:resource="#Catalysis4" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction5">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:participantStoichiometry rdf:resource="#Stoichiometry15" />
+    <bp:left rdf:resource="#SmallMolecule12" />
+    <bp:left rdf:resource="#SmallMolecule11" />
+    <bp:right rdf:resource="#SmallMolecule6" />
+    <bp:participantStoichiometry rdf:resource="#Stoichiometry16" />
+    <bp:right rdf:resource="#SmallMolecule13" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.1.1.153</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTHP is reduced to BH4 by sepiapterin reductase (SPR)</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref94" />
+    <bp:xref rdf:resource="#UnificationXref95" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sepiapterin reductase (SPR) (Ichinose et al. 1991) reduces DHNTP to tetrahydrobiopterin (BH4).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref10" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule12">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TPNH</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADPH</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference12" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29364</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref89" />
+    <bp:xref rdf:resource="#UnificationXref90" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref15" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference12">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADPH(4-) [ChEBI:57783]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADPH(4-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2'-O-phosphonatoadenosine 5'-{3-[1-(3-carbamoyl-1,4-dihydropyridin-1-yl)-1,4-anhydro-D-ribitol-5-yl] diphosphate}</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADPH</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADPH tetraanion</bp:name>
+    <bp:xref rdf:resource="#UnificationXref88" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref88">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:57783</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref89">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29364</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29364</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref90">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29364</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29364.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref15">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00005</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry15">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule12" />
+  </bp:Stoichiometry>
+  <bp:SmallMolecule rdf:ID="SmallMolecule13">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TPN</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP+</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP(+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nicotinamide adenine dinucleotide phosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">beta-Nicotinamide adenine dinucleotide phosphate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Triphosphopyridine nucleotide</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP(3-)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference13" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29366</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref92" />
+    <bp:xref rdf:resource="#UnificationXref93" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref16" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference13">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP(3-) [ChEBI:58349]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2'-O-phosphonatoadenosine 5'-{3-[1-(3-carbamoylpyridinio)-1,4-anhydro-D-ribitol-5-yl] diphosphate}</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP(+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADP trianion</bp:name>
+    <bp:xref rdf:resource="#UnificationXref91" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref91">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:58349</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref92">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29366</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29366</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref93">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29366</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29366.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref16">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00006</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry16">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule13" />
+  </bp:Stoichiometry>
+  <bp:Catalysis rdf:ID="Catalysis5">
+    <bp:controller rdf:resource="#Complex8" />
+    <bp:controlled rdf:resource="#BiochemicalReaction5" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref17" />
+    <bp:xref rdf:resource="#RelationshipXref18" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:RelationshipXref rdf:ID="RelationshipXref17">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0004757</bp:id>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary2" />
+  </bp:RelationshipXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref18">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497839</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497839</bp:comment>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary3" />
+  </bp:RelationshipXref>
+  <bp:UnificationXref rdf:ID="UnificationXref94">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1475414</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1475414</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref95">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1475414</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1475414.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref10">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1883349</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1991</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cloning and sequencing of cDNA encoding human sepiapterin reductase--an enzyme involved in tetrahydrobiopterin biosynthesis</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ichinose, H</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Katoh, S</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sueoka, T</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Titani, K</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fujita, K</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nagatsu, T</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biochem Biophys Res Commun 179:183-9</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep5">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction5" />
+    <bp:nextStep rdf:resource="#PathwayStep7" />
+    <bp:nextStep rdf:resource="#PathwayStep8" />
+    <bp:stepProcess rdf:resource="#Catalysis5" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction6">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule11" />
+    <bp:right rdf:resource="#SmallMolecule14" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Unknown sepiapterin synthase transforms PTHP to sepiapterin</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref101" />
+    <bp:xref rdf:resource="#UnificationXref102" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In an alternative salvage pathway for BH4 synthesis, dyspropterin (PTHP) may be transformed to sepiapterin, possibly non-enzymatically or by an unknown sepiapterin synthase enzyme (Crabtree &amp; Channon 2011).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref11" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, Bijay, 2020-07-06</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, Peter, 2020-07-06</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, Bijay, 2020-07-06</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule14">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sepiapterin</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference14" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497811</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref97" />
+    <bp:xref rdf:resource="#UnificationXref98" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference14">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sepiapterin [ChEBI:16095]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sepiapterin</bp:name>
+    <bp:xref rdf:resource="#UnificationXref96" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref96">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:16095</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref97">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497811</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497811</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref98">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1497811</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1497811.2</bp:comment>
+  </bp:UnificationXref>
+  <bp:Catalysis rdf:ID="Catalysis6">
+    <bp:controller rdf:resource="#PhysicalEntity1" />
+    <bp:controlled rdf:resource="#BiochemicalReaction6" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref20" />
+    <bp:xref rdf:resource="#RelationshipXref21" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:PhysicalEntity rdf:ID="PhysicalEntity1">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sepiapterin synthase</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 9693721</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref99" />
+    <bp:xref rdf:resource="#UnificationXref100" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref19" />
+  </bp:PhysicalEntity>
+  <bp:UnificationXref rdf:ID="UnificationXref99">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9693721</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=9693721</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref100">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-9693721</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-9693721.2</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref19">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">36080</bp:id>
+  </bp:RelationshipXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref20">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0016491</bp:id>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary2" />
+  </bp:RelationshipXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref21">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9693719</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=9693719</bp:comment>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary3" />
+  </bp:RelationshipXref>
+  <bp:UnificationXref rdf:ID="UnificationXref101">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9693722</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=9693722</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref102">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-9693722</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-9693722.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref11">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">21550412</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2011</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synthesis and recycling of tetrahydrobiopterin in endothelial function and vascular disease</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crabtree, MJ</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Channon, KM</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nitric Oxide 25:81-8</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep6">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction6" />
+    <bp:stepProcess rdf:resource="#Catalysis6" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction7">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule6" />
+    <bp:right rdf:resource="#SmallMolecule15" />
+    <bp:right rdf:resource="#SmallMolecule16" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH4 is oxidised to the BH3 radical during the eNOS catalytic cycle</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref109" />
+    <bp:xref rdf:resource="#UnificationXref110" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH4 donates an electron to the eNOS catalytic cycle and is oxidised to the BH3 radical (BH3.-) (Berka et al. 2004).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref12" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule15">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">e-</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electron</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference15" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 879326</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref104" />
+    <bp:xref rdf:resource="#UnificationXref105" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference15">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electron [ChEBI:10545]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electron</bp:name>
+    <bp:xref rdf:resource="#UnificationXref103" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref103">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:10545</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref104">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">879326</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=879326</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref105">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-879326</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-879326.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule16">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH3.</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH3 radical</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5,6,7,8-tetrahydrobiopterin radical cation</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference16" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497797</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref107" />
+    <bp:xref rdf:resource="#UnificationXref108" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference16">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5,6,7,8-tetrahydrobiopterin radical cation [ChEBI:62772]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5,6,7,8-tetrahydrobiopterin radical cation</bp:name>
+    <bp:xref rdf:resource="#UnificationXref106" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref106">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:62772</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref107">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497797</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497797</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref108">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1497797</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1497797.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref109">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497824</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497824</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref110">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497824</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497824.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref12">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">15476407</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2004</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Redox function of tetrahydrobiopterin and effect of L-arginine on oxygen binding in endothelial nitric oxide synthase</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Berka, V</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yeh, HC</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gao, D</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kiran, F</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tsai, AL</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biochemistry 43:13137-48</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep7">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction7" />
+    <bp:nextStep rdf:resource="#PathwayStep11" />
+    <bp:nextStep rdf:resource="#PathwayStep10" />
+    <bp:nextStep rdf:resource="#PathwayStep9" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction8">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule6" />
+    <bp:left rdf:resource="#SmallMolecule17" />
+    <bp:right rdf:resource="#SmallMolecule16" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxynitrite can oxidise BH4 to the BH3 radical</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref114" />
+    <bp:xref rdf:resource="#UnificationXref115" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxynitrite can oxidise BH4 to the BH3 radical, further reducing BH4 availability to couple eNOS activity and compounding the production of superoxide through uncoupled eNOS activity (Kuzkaya et al. 2003).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref13" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule17">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ONOO-</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxynitrite</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference17" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1222481</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref112" />
+    <bp:xref rdf:resource="#UnificationXref113" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference17">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peroxynitrite [ChEBI:25941]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peroxynitrite</bp:name>
+    <bp:xref rdf:resource="#UnificationXref111" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref111">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:25941</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref112">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1222481</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1222481</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref113">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1222481</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1222481.2</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref114">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497866</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497866</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref115">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497866</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497866.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref13">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">12692136</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2003</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interactions of peroxynitrite, tetrahydrobiopterin, ascorbic acid, and thiols: implications for uncoupling endothelial nitric-oxide synthase</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kuzkaya, N</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Weissmann, N</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Harrison, DG</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dikalov, S</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Biol Chem 278:22546-54</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep8">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction8" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction9">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule18" />
+    <bp:left rdf:resource="#SmallMolecule16" />
+    <bp:right rdf:resource="#SmallMolecule6" />
+    <bp:right rdf:resource="#SmallMolecule19" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ferrous iron reduces the BH3 radical back to BH4</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref122" />
+    <bp:xref rdf:resource="#UnificationXref123" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heme iron from the oxygenase domain of eNOS can reduce the BH3 radical back to BH4, with itself being oxidised from the ferrous (Fe2+) back to the ferric (Fe3+) form (Berka et al. 2004).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref12" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule18">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe2+</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron (ferrous)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron atom</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe(II)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe++</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Iron</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe3+</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe(III)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference18" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 71067</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref117" />
+    <bp:xref rdf:resource="#UnificationXref118" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref22" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference18">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron(2+) [ChEBI:29033]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron(2+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FE (II) ION</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe2+</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe(2+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron ion(2+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe(II)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ferrous ion</bp:name>
+    <bp:xref rdf:resource="#UnificationXref116" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref116">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:29033</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref117">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">71067</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=71067</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref118">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-71067</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-71067.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref22">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00023</bp:id>
+  </bp:RelationshipXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule19">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe3+</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron (ferric)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron(3+)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference19" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 111736</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref120" />
+    <bp:xref rdf:resource="#UnificationXref121" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref22" />
+    <bp:xref rdf:resource="#RelationshipXref23" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference19">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron(3+) [ChEBI:29034]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron(3+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ferric iron</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iron, ion (Fe(3+))</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe(3+)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe(III)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fe3+</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FE (III) ION</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ferric ion</bp:name>
+    <bp:xref rdf:resource="#UnificationXref119" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref119">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:29034</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref120">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">111736</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=111736</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref121">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-111736</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-111736.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref23">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00023</bp:id>
+  </bp:RelationshipXref>
+  <bp:UnificationXref rdf:ID="UnificationXref122">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497883</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497883</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref123">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497883</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497883.2</bp:comment>
+  </bp:UnificationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep9">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction9" />
+    <bp:nextStep rdf:resource="#PathwayStep5" />
+    <bp:nextStep rdf:resource="#PathwayStep7" />
+    <bp:nextStep rdf:resource="#PathwayStep8" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction10">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule16" />
+    <bp:left rdf:resource="#SmallMolecule20" />
+    <bp:right rdf:resource="#SmallMolecule6" />
+    <bp:right rdf:resource="#SmallMolecule21" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ascorbate can reduce the BH3 radical back to BH4</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref130" />
+    <bp:xref rdf:resource="#UnificationXref131" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ascorbate (AscH-) can reduce the BH3 radical back to BH4, thereby maintaining BH4 levels (Baker et al. 2001, Patel et al. 2002, Kuzkaya et al. 2003).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref14" />
+    <bp:xref rdf:resource="#PublicationXref13" />
+    <bp:xref rdf:resource="#PublicationXref15" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule20">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AscH-</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ascorbate</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference20" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 198816</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref125" />
+    <bp:xref rdf:resource="#UnificationXref126" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference20">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-ascorbate [ChEBI:38290]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-ascorbate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-ascorbic acid</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin C</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ascorbate</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L-ascorbate (vitamin C)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ascorbic acid</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smallMolecule6537</bp:name>
+    <bp:xref rdf:resource="#UnificationXref124" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref124">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:38290</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref125">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">198816</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=198816</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref126">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-198816</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-198816.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:SmallMolecule rdf:ID="SmallMolecule21">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Asc.-</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ascorbate radical</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">monodehydroascorbate anion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">monodehydro-L-ascorbate(1-)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference21" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497805</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref128" />
+    <bp:xref rdf:resource="#UnificationXref129" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference21">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">monodehydro-L-ascorbate(1-) [ChEBI:59513]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">monodehydro-L-ascorbate(1-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">monodehydroascorbate anion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">monodehydro-L-ascorbate</bp:name>
+    <bp:xref rdf:resource="#UnificationXref127" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref127">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:59513</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref128">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497805</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497805</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref129">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1497805</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1497805.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref130">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497855</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497855</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref131">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497855</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497855.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref14">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">11243424</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2001</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Effect of vitamin C on the availability of tetrahydrobiopterin in human endothelial cells</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Baker, TA</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Milstien, S</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Katusic, ZS</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Cardiovasc Pharmacol 37:333-8</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref15">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">11827745</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2002</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oxidation of tetrahydrobiopterin by biological radicals and scavenging of the trihydrobiopterin radical by ascorbate</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Patel, KB</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stratford, MR</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wardman, P</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Everett, SA</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Free Radic Biol Med 32:203-11</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep10">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction10" />
+    <bp:nextStep rdf:resource="#PathwayStep7" />
+    <bp:nextStep rdf:resource="#PathwayStep8" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction11">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule16" />
+    <bp:right rdf:resource="#SmallMolecule22" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The BH3 radical can decay to dihydrobiopterin (BH2)</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref135" />
+    <bp:xref rdf:resource="#UnificationXref136" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH4 oxidation results in the radical BH3. which decays to 7,8-dihydrobiopterin (BH2) (Milstien &amp; Katusic, 1999).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref16" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule22">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH2</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dihydrobiopterin</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-erythro-7,8-dihydrobiopterin</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7,8-dihydrobiopterin</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference22" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497857</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref133" />
+    <bp:xref rdf:resource="#UnificationXref134" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference22">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-erythro-7,8-dihydrobiopterin [ChEBI:15375]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-erythro-7,8-dihydrobiopterin</bp:name>
+    <bp:xref rdf:resource="#UnificationXref132" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref132">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:15375</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref133">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497857</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497857</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref134">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-1497857</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-1497857.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref135">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497863</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497863</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref136">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497863</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497863.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref16">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10512739</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1999</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oxidation of tetrahydrobiopterin by peroxynitrite: implications for vascular endothelial function</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Milstien, S</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Katusic, Z</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biochem Biophys Res Commun 263:681-4</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep11">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction11" />
+    <bp:nextStep rdf:resource="#PathwayStep13" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction12">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule6" />
+    <bp:left rdf:resource="#Complex9" />
+    <bp:right rdf:resource="#Complex12" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The cofactor BH4 is required for electron transfer in the eNOS catalytic cycle</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref173" />
+    <bp:xref rdf:resource="#UnificationXref174" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The cofactor tetrahydrobiopterin (BH4) ensures endothelial nitric oxide synthase (eNOS) couples electron transfer to L-arginine oxidation (Berka et al. 2004). During catalysis, electrons derived from NADPH transfer to the flavins FAD and FMN in the reductase domain of eNOS and then on to the ferric heme in the oxygenase domain of eNOS. BH4 can donate an electron to intermediates in this electron transfer and is oxidised in the process, forming the BH3 radical. This radical can be reduced back to BH4 by iron, completing the cycle and forming ferrous iron again. Heme reduction enables O2 binding and L-arginine oxidation to occur within the oxygenase domain (Stuehr et al. 2009).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref12" />
+    <bp:xref rdf:resource="#PublicationXref17" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:Complex rdf:ID="Complex9">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S1177-eNOS:CaM:HSP90:p-AKT1</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary2" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry23" />
+    <bp:component rdf:resource="#Complex10" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry24" />
+    <bp:component rdf:resource="#Protein9" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry27" />
+    <bp:component rdf:resource="#Complex11" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry28" />
+    <bp:component rdf:resource="#Protein11" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 202121</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref169" />
+    <bp:xref rdf:resource="#UnificationXref170" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:CellularLocationVocabulary rdf:ID="CellularLocationVocabulary2">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">plasma membrane</bp:term>
+    <bp:xref rdf:resource="#UnificationXref137" />
+  </bp:CellularLocationVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref137">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0005886</bp:id>
+  </bp:UnificationXref>
+  <bp:Complex rdf:ID="Complex10">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S1177-eNOS dimer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary2" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry17" />
+    <bp:component rdf:resource="#SmallMolecule6" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry18" />
+    <bp:component rdf:resource="#SmallMolecule23" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry19" />
+    <bp:component rdf:resource="#Protein8" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry20" />
+    <bp:component rdf:resource="#SmallMolecule24" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry21" />
+    <bp:component rdf:resource="#SmallMolecule25" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry22" />
+    <bp:component rdf:resource="#SmallMolecule9" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 203564</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref152" />
+    <bp:xref rdf:resource="#UnificationXref153" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Stoichiometry rdf:ID="Stoichiometry17">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule6" />
+  </bp:Stoichiometry>
+  <bp:SmallMolecule rdf:ID="SmallMolecule23">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMN</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flavin mononucleotide</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Riboflavin-5-phosphate</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference23" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 73524</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref139" />
+    <bp:xref rdf:resource="#UnificationXref140" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref24" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference23">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMN(3-) [ChEBI:58210]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMN(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">riboflavin 5'-phosphate(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7,8-dimethyl-2,4-dioxo-10-[(2S,3S,4R)-2,3,4-trihydroxy-5-(phosphonatooxy)pentyl]-2H,3H,4H,10H-benzo[g]pteridin-3-ide</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">flavin mononucleotide trianion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">riboflavin 5'-monophosphate(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">flavin mononucleotide(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">riboflavin 5'-phosphate trianion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1-deoxy-1-(7,8-dimethyl-2,4-dioxo-2H-benzo[g]pteridin-3-id-10(4H)-yl)-5-O-phosphonato-D-ribitol</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMN</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMN trianion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">riboflavin 5'-monophosphate trianion</bp:name>
+    <bp:xref rdf:resource="#UnificationXref138" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref138">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:58210</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref139">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">73524</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=73524</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref140">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-73524</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-73524.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref24">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00061</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry18">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule23" />
+  </bp:Stoichiometry>
+  <bp:Protein rdf:ID="Protein8">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S1177-eNOS</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2xPalmC-MyrG-p-S1177-NOS3</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary2" />
+    <bp:entityReference rdf:resource="#ProteinReference6" />
+    <bp:feature rdf:resource="#ModificationFeature3" />
+    <bp:feature rdf:resource="#ModificationFeature4" />
+    <bp:feature rdf:resource="#ModificationFeature5" />
+    <bp:feature rdf:resource="#ModificationFeature6" />
+    <bp:feature rdf:resource="#FragmentFeature8" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 202139</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref144" />
+    <bp:xref rdf:resource="#UnificationXref145" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference6">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P29474 NOS3</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NOS3</bp:name>
+    <bp:xref rdf:resource="#UnificationXref141" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Produces nitric oxide (NO) which is implicated in vascular smooth muscle relaxation through a cGMP-mediated signal transduction pathway (PubMed:1378832). NO mediates vascular endothelial growth factor (VEGF)-induced angiogenesis in coronary vessels and promotes blood clotting through the activation of platelets.ACTIVITY REGULATION Stimulated by calcium/calmodulin. Inhibited by NOSIP and NOSTRIN.SUBUNIT Homodimer. Interacts with NOSIP and NOSTRIN (PubMed:11149895, PubMed:12446846). Interacts with HSP90AB1 (PubMed:23585225, PubMed:11149895, PubMed:12446846) (By similarity). Forms a complex with ASL, ASS1 and SLC7A1; the complex regulates cell-autonomous L-arginine synthesis and citrulline recycling while channeling extracellular L-arginine to nitric oxide synthesis pathway (By similarity).TISSUE SPECIFICITY Platelets, placenta, liver and kidney.PTM Phosphorylation by AMPK at Ser-1177 in the presence of Ca(2+)-calmodulin (CaM) activates activity. In absence of Ca(2+)-calmodulin, AMPK also phosphorylates Thr-495, resulting in inhibition of activity (By similarity). Phosphorylation of Ser-114 by CDK5 reduces activity.DISEASE Variation Asp-298 in NOS3 may be associated with susceptibility to coronary spasm.SIMILARITY Belongs to the NOS family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref141">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P29474</bp:id>
+  </bp:UnificationXref>
+  <bp:ModificationFeature rdf:ID="ModificationFeature3">
+    <bp:featureLocation rdf:resource="#SequenceSite17" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary1" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite17">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1177</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:ModificationFeature rdf:ID="ModificationFeature4">
+    <bp:featureLocation rdf:resource="#SequenceSite18" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary2" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite18">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">15</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceModificationVocabulary rdf:ID="SequenceModificationVocabulary2">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S-palmitoyl-L-cysteine</bp:term>
+    <bp:xref rdf:resource="#UnificationXref142" />
+  </bp:SequenceModificationVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref142">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD:00115</bp:id>
+  </bp:UnificationXref>
+  <bp:ModificationFeature rdf:ID="ModificationFeature5">
+    <bp:featureLocation rdf:resource="#SequenceSite19" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary2" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite19">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">26</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:ModificationFeature rdf:ID="ModificationFeature6">
+    <bp:featureLocation rdf:resource="#SequenceSite20" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary3" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite20">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceModificationVocabulary rdf:ID="SequenceModificationVocabulary3">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">N-myristoylglycine</bp:term>
+    <bp:xref rdf:resource="#UnificationXref143" />
+  </bp:SequenceModificationVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref143">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD:00068</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature8">
+    <bp:featureLocation rdf:resource="#SequenceInterval8" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval8">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite21" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite22" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite21">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite22">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1203</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref144">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">202139</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=202139</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref145">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-202139</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-202139.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry19">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein8" />
+  </bp:Stoichiometry>
+  <bp:SmallMolecule rdf:ID="SmallMolecule24">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heme</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heme</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ferroheme b</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heme (ferrous)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference24" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 71185</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref147" />
+    <bp:xref rdf:resource="#UnificationXref148" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref25" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference24">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ferroheme b [ChEBI:17627]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ferroheme b</bp:name>
+    <bp:xref rdf:resource="#UnificationXref146" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref146">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:17627</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref147">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">71185</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=71185</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref148">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-71185</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-71185.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref25">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00032</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry20">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule24" />
+  </bp:Stoichiometry>
+  <bp:SmallMolecule rdf:ID="SmallMolecule25">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAD</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAD(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flavin adenine dinucleotide</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference25" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 29386</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref150" />
+    <bp:xref rdf:resource="#UnificationXref151" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref26" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference25">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAD(3-) [ChEBI:57692]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAD(3-)</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAD trianion</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAD</bp:name>
+    <bp:xref rdf:resource="#UnificationXref149" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref149">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:57692</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref150">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">29386</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=29386</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref151">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-29386</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-29386.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref26">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00016</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry21">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule25" />
+  </bp:Stoichiometry>
+  <bp:Stoichiometry rdf:ID="Stoichiometry22">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule9" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref152">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">203564</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=203564</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref153">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-203564</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-203564.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry23">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex10" />
+  </bp:Stoichiometry>
+  <bp:Protein rdf:ID="Protein9">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PKB</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-T308,S473-AKT1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S473,T308-AKT1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-T308, S473-AKT1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RAC-alpha serine/threonine kinase</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RAC-PK-alpha</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein kinase B</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-AKT</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference7" />
+    <bp:feature rdf:resource="#ModificationFeature7" />
+    <bp:feature rdf:resource="#ModificationFeature8" />
+    <bp:feature rdf:resource="#FragmentFeature9" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 198356</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref156" />
+    <bp:xref rdf:resource="#UnificationXref157" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference7">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P31749 AKT1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AKT1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PKB</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RAC</bp:name>
+    <bp:xref rdf:resource="#UnificationXref154" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION AKT1 is one of 3 closely related serine/threonine-protein kinases (AKT1, AKT2 and AKT3) called the AKT kinase, and which regulate many processes including metabolism, proliferation, cell survival, growth and angiogenesis (PubMed:15526160, PubMed:11882383, PubMed:21620960, PubMed:21432781). This is mediated through serine and/or threonine phosphorylation of a range of downstream substrates (PubMed:15526160, PubMed:11882383, PubMed:21620960, PubMed:21432781). Over 100 substrate candidates have been reported so far, but for most of them, no isoform specificity has been reported (PubMed:15526160, PubMed:11882383, PubMed:21620960, PubMed:21432781). AKT is responsible of the regulation of glucose uptake by mediating insulin-induced translocation of the SLC2A4/GLUT4 glucose transporter to the cell surface (By similarity). Phosphorylation of PTPN1 at 'Ser-50' negatively modulates its phosphatase activity preventing dephosphorylation of the insulin receptor and the attenuation of insulin signaling (By similarity). Phosphorylation of TBC1D4 triggers the binding of this effector to inhibitory 14-3-3 proteins, which is required for insulin-stimulated glucose transport (PubMed:11994271). AKT regulates also the storage of glucose in the form of glycogen by phosphorylating GSK3A at 'Ser-21' and GSK3B at 'Ser-9', resulting in inhibition of its kinase activity (By similarity). Phosphorylation of GSK3 isoforms by AKT is also thought to be one mechanism by which cell proliferation is driven (By similarity). AKT regulates also cell survival via the phosphorylation of MAP3K5 (apoptosis signal-related kinase) (PubMed:11154276). Phosphorylation of 'Ser-83' decreases MAP3K5 kinase activity stimulated by oxidative stress and thereby prevents apoptosis (PubMed:11154276). AKT mediates insulin-stimulated protein synthesis by phosphorylating TSC2 at 'Ser-939' and 'Thr-1462', thereby activating the TORC1 signaling pathway, and leading to both phosphorylation of 4E-BP1 and in activation of RPS6KB1 (PubMed:12150915). Also regulates the TORC1 signaling pathway by catalyzing phosphorylation of CASTOR1 (PubMed:33594058). AKT is involved in the phosphorylation of members of the FOXO factors (Forkhead family of transcription factors), leading to binding of 14-3-3 proteins and cytoplasmic localization (PubMed:10358075). In particular, FOXO1 is phosphorylated at 'Thr-24', 'Ser-256' and 'Ser-319' (PubMed:10358075). FOXO3 and FOXO4 are phosphorylated on equivalent sites (PubMed:10358075). AKT has an important role in the regulation of NF-kappa-B-dependent gene transcription and positively regulates the activity of CREB1 (cyclic AMP (cAMP)-response element binding protein) (PubMed:9829964). The phosphorylation of CREB1 induces the binding of accessory proteins that are necessary for the transcription of pro-survival genes such as BCL2 and MCL1 (PubMed:9829964). AKT phosphorylates 'Ser-454' on ATP citrate lyase (ACLY), thereby potentially regulating ACLY activity and fatty acid synthesis (By similarity). Activates the 3B isoform of cyclic nucleotide phosphodiesterase (PDE3B) via phosphorylation of 'Ser-273', resulting in reduced cyclic AMP levels and inhibition of lipolysis (By similarity). Phosphorylates PIKFYVE on 'Ser-318', which results in increased PI(3)P-5 activity (By similarity). The Rho GTPase-activating protein DLC1 is another substrate and its phosphorylation is implicated in the regulation cell proliferation and cell growth. AKT plays a role as key modulator of the AKT-mTOR signaling pathway controlling the tempo of the process of newborn neurons integration during adult neurogenesis, including correct neuron positioning, dendritic development and synapse formation (By similarity). Signals downstream of phosphatidylinositol 3-kinase (PI(3)K) to mediate the effects of various growth factors such as platelet-derived growth factor (PDGF), epidermal growth factor (EGF), insulin and insulin-like growth factor I (IGF-I) (PubMed:12176338, PubMed:12964941). AKT mediates the antiapoptotic effects of IGF-I (By similarity). Essential for the SPATA13-mediated regulation of cell migration and adhesion assembly and disassembly (PubMed:19934221). May be involved in the regulation of the placental development (By similarity). Phosphorylates STK4/MST1 at 'Thr-120' and 'Thr-387' leading to inhibition of its: kinase activity, nuclear translocation, autophosphorylation and ability to phosphorylate FOXO3 (PubMed:17726016). Phosphorylates STK3/MST2 at 'Thr-117' and 'Thr-384' leading to inhibition of its: cleavage, kinase activity, autophosphorylation at Thr-180, binding to RASSF1 and nuclear translocation (PubMed:20086174, PubMed:20231902). Phosphorylates SRPK2 and enhances its kinase activity towards SRSF2 and ACIN1 and promotes its nuclear translocation (PubMed:19592491). Phosphorylates RAF1 at 'Ser-259' and negatively regulates its activity (PubMed:10576742). Phosphorylation of BAD stimulates its pro-apoptotic activity (PubMed:10926925). Phosphorylates KAT6A at 'Thr-369' and this phosphorylation inhibits the interaction of KAT6A with PML and negatively regulates its acetylation activity towards p53/TP53 (PubMed:23431171). Phosphorylates palladin (PALLD), modulating cytoskeletal organization and cell motility (PubMed:20471940). Phosphorylates prohibitin (PHB), playing an important role in cell metabolism and proliferation (PubMed:18507042). Phosphorylates CDKN1A, for which phosphorylation at 'Thr-145' induces its release from CDK2 and cytoplasmic relocalization (PubMed:16982699). These recent findings indicate that the AKT1 isoform has a more specific role in cell motility and proliferation (PubMed:16139227). Phosphorylates CLK2 thereby controlling cell survival to ionizing radiation (PubMed:20682768). Phosphorylates PCK1 at 'Ser-90', reducing the binding affinity of PCK1 to oxaloacetate and changing PCK1 into an atypical protein kinase activity using GTP as donor (PubMed:32322062). Also acts as an activator of TMEM175 potassium channel activity in response to growth factors: forms the lysoK(GF) complex together with TMEM175 and acts by promoting TMEM175 channel activation, independently of its protein kinase activity (PubMed:32228865).ACTIVITY REGULATION Three specific sites, one in the kinase domain (Thr-308) and the two other ones in the C-terminal regulatory region (Ser-473 and Tyr-474), need to be phosphorylated for its full activation (PubMed:20481595, PubMed:21392984, PubMed:9512493, PubMed:9736715). Inhibited by pyrrolopyrimidine inhibitors like aniline triazole and spiroindoline (PubMed:18456494, PubMed:20810279).SUBUNIT Interacts with BTBD10 (By similarity). Interacts with KCTD20 (By similarity). Interacts (via the C-terminus) with CCDC88A (via its C-terminus). Interacts with GRB10; the interaction leads to GRB10 phosphorylation thus promoting YWHAE-binding (By similarity). Interacts with AGAP2 (isoform 2/PIKE-A); the interaction occurs in the presence of guanine nucleotides. Interacts with AKTIP. Interacts (via PH domain) with MTCP1, TCL1A and TCL1B. Interacts with CDKN1B; the interaction phosphorylates CDKN1B promoting 14-3-3 binding and cell-cycle progression. Interacts with MAP3K5 and TRAF6. Interacts with BAD, PPP2R5B, STK3 and STK4. Interacts (via PH domain) with SIRT1. Interacts with SRPK2 in a phosphorylation-dependent manner. Interacts with RAF1. Interacts with TRIM13; the interaction ubiquitinates AKT1 leading to its proteasomal degradation. Interacts with TNK2 and CLK2. Interacts (via the C-terminus) with THEM4 (via its C-terminus). Interacts with and phosphorylated by PDPK1. Interacts with PA2G4 (By similarity). Interacts with KIF14; the interaction is detected in the plasma membrane upon INS stimulation and promotes AKT1 phosphorylation (PubMed:24784001). Interacts with FAM83B; activates the PI3K/AKT signaling cascade (PubMed:23676467). Interacts with WDFY2 (via WD repeats 1-3) (PubMed:16792529). Forms a complex with WDFY2 and FOXO1 (By similarity). Interacts with FAM168A (PubMed:23251525). Interacts with SYAP1 (via phosphorylated form and BSD domain); this interaction is enhanced in a mTORC2-mediated manner in response to epidermal growth factor (EGF) stimulation and activates AKT1 (PubMed:23300339). Interacts with PKHM3 (By similarity). Interacts with FKBP5/FKBP51; promoting interaction between Akt/AKT1 and PHLPP1, thereby enhancing dephosphorylation and subsequent activation of Akt/AKT1 (PubMed:28147277). Interacts with TMEM175; leading to formation of the lysoK(GF) complex (PubMed:32228865). Acts as a negative regulator of the cGAS-STING pathway by mediating phosphorylation of CGAS during mitosis, leading to its inhibition (PubMed:26440888).TISSUE SPECIFICITY Expressed in prostate cancer and levels increase from the normal to the malignant state (at protein level). Expressed in all human cell types so far analyzed. The Tyr-176 phosphorylated form shows a significant increase in expression in breast cancers during the progressive stages i.e. normal to hyperplasia (ADH), ductal carcinoma in situ (DCIS), invasive ductal carcinoma (IDC) and lymph node metastatic (LNMM) stages.DOMAIN Binding of the PH domain to phosphatidylinositol 3,4,5-trisphosphate (PI(3,4,5)P3) following phosphatidylinositol 3-kinase alpha (PIK3CA) activity results in its targeting to the plasma membrane. The PH domain mediates interaction with TNK2 and Tyr-176 is also essential for this interaction.DOMAIN The AGC-kinase C-terminal mediates interaction with THEM4.PTM O-GlcNAcylation at Thr-305 and Thr-312 inhibits activating phosphorylation at Thr-308 via disrupting the interaction between AKT1 and PDPK1. O-GlcNAcylation at Ser-473 also probably interferes with phosphorylation at this site.PTM Phosphorylation on Thr-308, Ser-473 and Tyr-474 is required for full activity (PubMed:12149249, PubMed:14761976, PubMed:15047712, PubMed:16266983, PubMed:17013611, PubMed:20978158, PubMed:9736715, PubMed:23799035, PubMed:8978681, PubMed:28147277). Activated TNK2 phosphorylates it on Tyr-176 resulting in its binding to the anionic plasma membrane phospholipid PA (PubMed:20333297). This phosphorylated form localizes to the cell membrane, where it is targeted by PDPK1 and PDPK2 for further phosphorylations on Thr-308 and Ser-473 leading to its activation (PubMed:9512493). Ser-473 phosphorylation by mTORC2 favors Thr-308 phosphorylation by PDPK1 (PubMed:21464307, PubMed:8978681). Phosphorylated at Thr-308 and Ser-473 by IKBKE and TBK1 (PubMed:15718470, PubMed:18456494, PubMed:20481595, PubMed:8978681). Ser-473 phosphorylation is enhanced by interaction with AGAP2 isoform 2 (PIKE-A) (PubMed:14761976). Ser-473 phosphorylation is enhanced in focal cortical dysplasias with Taylor-type balloon cells (PubMed:17013611). Ser-473 phosphorylation is enhanced by signaling through activated FLT3 (By similarity). Ser-473 is dephosphorylated by PHLPP (PubMed:28147277). Dephosphorylated at Thr-308 and Ser-473 by PP2A phosphatase (PubMed:21329884). The phosphorylated form of PPP2R5B is required for bridging AKT1 with PP2A phosphatase (PubMed:21329884). Ser-473 is dephosphorylated by CPPED1, leading to termination of signaling (PubMed:9512493).PTM Ubiquitinated; undergoes both 'Lys-48'- and 'Lys-63'-linked polyubiquitination. TRAF6-induced 'Lys-63'-linked AKT1 ubiquitination is critical for phosphorylation and activation (PubMed:19713527). When ubiquitinated, it translocates to the plasma membrane, where it becomes phosphorylated (PubMed:20059950). When fully phosphorylated and translocated into the nucleus, undergoes 'Lys-48'-polyubiquitination catalyzed by TTC3, leading to its degradation by the proteasome (PubMed:20059950). Also ubiquitinated by TRIM13 leading to its proteasomal degradation (PubMed:21333377). Phosphorylated, undergoes 'Lys-48'-linked polyubiquitination preferentially at Lys-284 catalyzed by MUL1, leading to its proteasomal degradation (PubMed:22410793). Ubiquitinated via 'Lys-48'-linked polyubiquitination by ZNRF1, leading to its degradation by the proteasome (By similarity).PTM Acetylated on Lys-14 and Lys-20 by the histone acetyltransferases EP300 and KAT2B. Acetylation results in reduced phosphorylation and inhibition of activity. Deacetylated at Lys-14 and Lys-20 by SIRT1. SIRT1-mediated deacetylation relieves the inhibition.PTM Cleavage by caspase-3/CASP3 (By similarity). Cleaved at the caspase-3 consensus site Asp-462 during apoptosis, resulting in down-regulation of the AKT signaling pathway and decreased cell survival (PubMed:23152800).DISEASE Genetic variations in AKT1 may play a role in susceptibility to ovarian cancer.SIMILARITY Belongs to the protein kinase superfamily. AGC Ser/Thr protein kinase family. RAC subfamily.CAUTION PUBMED:19940129 has been retracted because the same data were used to represent different experimental conditions.CAUTION In light of strong homologies in the primary amino acid sequence, the 3 AKT kinases were long surmised to play redundant and overlapping roles. More recent studies has brought into question the redundancy within AKT kinase isoforms and instead pointed to isoform specific functions in different cellular events and diseases. AKT1 is more specifically involved in cellular survival pathways, by inhibiting apoptotic processes; whereas AKT2 is more specific for the insulin receptor signaling pathway. Moreover, while AKT1 and AKT2 are often implicated in many aspects of cellular transformation, the 2 isoforms act in a complementary opposing manner. The role of AKT3 is less clear, though it appears to be predominantly expressed in brain.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref154">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P31749</bp:id>
+  </bp:UnificationXref>
+  <bp:ModificationFeature rdf:ID="ModificationFeature7">
+    <bp:featureLocation rdf:resource="#SequenceSite23" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary4" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite23">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">308</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceModificationVocabulary rdf:ID="SequenceModificationVocabulary4">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O-phospho-L-threonine</bp:term>
+    <bp:xref rdf:resource="#UnificationXref155" />
+  </bp:SequenceModificationVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref155">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MOD:00047</bp:id>
+  </bp:UnificationXref>
+  <bp:ModificationFeature rdf:ID="ModificationFeature8">
+    <bp:featureLocation rdf:resource="#SequenceSite24" />
+    <bp:modificationType rdf:resource="#SequenceModificationVocabulary1" />
+  </bp:ModificationFeature>
+  <bp:SequenceSite rdf:ID="SequenceSite24">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">473</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:FragmentFeature rdf:ID="FragmentFeature9">
+    <bp:featureLocation rdf:resource="#SequenceInterval9" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval9">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite25" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite26" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite25">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite26">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">480</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref156">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">198356</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=198356</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref157">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-198356</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-198356.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry24">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein9" />
+  </bp:Stoichiometry>
+  <bp:Complex rdf:ID="Complex11">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALM1:4xCa2+</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Active Calmodulin</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry25" />
+    <bp:component rdf:resource="#Protein10" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry26" />
+    <bp:component rdf:resource="#SmallMolecule26" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 74294</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref164" />
+    <bp:xref rdf:resource="#UnificationXref165" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein10">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALM1</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calmodulin</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALM_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference8" />
+    <bp:feature rdf:resource="#FragmentFeature10" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 9016707</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref159" />
+    <bp:xref rdf:resource="#UnificationXref160" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference8">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P0DP23 CALM1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALM1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALM</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAM</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAM1</bp:name>
+    <bp:xref rdf:resource="#UnificationXref158" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Calmodulin acts as part of a calcium signal transduction pathway by mediating the control of a large number of enzymes, ion channels, aquaporins and other proteins through calcium-binding (PubMed:16760425, PubMed:23893133, PubMed:26969752, PubMed:27165696, PubMed:28890335, PubMed:31454269, PubMed:35568036). Calcium-binding is required for the activation of calmodulin (PubMed:16760425, PubMed:23893133, PubMed:26969752, PubMed:27165696, PubMed:28890335, PubMed:31454269, PubMed:35568036). Among the enzymes to be stimulated by the calmodulin-calcium complex are a number of protein kinases, such as myosin light-chain kinases and calmodulin-dependent protein kinase type II (CaMK2), and phosphatases (PubMed:16760425, PubMed:23893133, PubMed:26969752, PubMed:27165696, PubMed:28890335, PubMed:31454269, PubMed:35568036). Together with CCP110 and centrin, is involved in a genetic pathway that regulates the centrosome cycle and progression through cytokinesis (PubMed:16760425). Is a regulator of voltage-dependent L-type calcium channels (PubMed:31454269). Mediates calcium-dependent inactivation of CACNA1C (PubMed:26969752). Positively regulates calcium-activated potassium channel activity of KCNN2 (PubMed:27165696). Forms a potassium channel complex with KCNQ1 and regulates electrophysiological activity of the channel via calcium-binding (PubMed:25441029). Acts as a sensor to modulate the endoplasmic reticulum contacts with other organelles mediated by VMP1:ATP2A2 (PubMed:28890335).FUNCTION (Microbial infection) Required for Legionella pneumophila SidJ glutamylase activity.FUNCTION (Microbial infection) Required for C.violaceum CopC arginine ADP-riboxanase activity.ACTIVITY REGULATION (Microbial infection) Inactivated by S.flexneri OspC1 and OspC3 proteins, which specifically bind the apo-form of calmodulin, thereby preventing calcium-binding and activity.SUBUNIT Interacts with MYO1C, MYO5A and RRAD. Interacts with MYO10 (By similarity). Interacts with CEP97, CCP110, TTN/titin and SRY (PubMed:9804419, PubMed:12871148, PubMed:15746192, PubMed:16760425, PubMed:17719545). Interacts with USP6; the interaction is calcium dependent (PubMed:16127172). Interacts with CDK5RAP2 (PubMed:20466722). Interacts with SCN5A (PubMed:21167176). Interacts with RYR1 (PubMed:18650434). Interacts with FCHO1 (PubMed:22484487). Interacts with MIP in a 1:2 stoichiometry; the interaction with the cytoplasmic domains from two MIP subunits promotes MIP water channel closure (PubMed:23893133). Interacts with ORAI1; this may play a role in the regulation of ORAI1-mediated calcium transport (By similarity). Interacts with IQCF1 (By similarity). Interacts with SYT7 (By similarity). Interacts with CEACAM1 (via cytoplasmic domain); this interaction is in a calcium dependent manner and reduces homophilic cell adhesion through dissociation of dimer (By similarity). Interacts with RYR2; regulates RYR2 calcium-release channel activity (PubMed:27516456, PubMed:18650434, PubMed:26164367). Interacts with PCP4; regulates calmodulin calcium-binding (PubMed:27876793). Interacts with the heterotetrameric KCNQ2 and KCNQ3 channel; the interaction is calcium-independent, constitutive and participates in the proper assembly of a functional heterotetrameric M channel (PubMed:27564677). Interacts with alpha-synuclein/SNCA (PubMed:23607618). Interacts with SLC9A1 in a calcium-dependent manner (PubMed:30287853). In the absence of Ca(+2), interacts with GIMAP4 (via IQ domain) (By similarity). Interacts with SCN8A; the interaction modulates the inactivation rate of SCN8A (By similarity). Interaction with KIF1A; the interaction is increased in presence of calcium and increases neuronal dense core vesicles motility (PubMed:30021165). Interacts with KCNN3 (PubMed:31155282). Interacts with KCNQ1 (via C-terminus); forms a heterooctameric structure (with 4:4 KCNQ1:CALM stoichiometry) in a calcium-independent manner (PubMed:18165683,PubMed:25441029). Interacts with PIK3C3; the interaction modulates PIK3C3 kinase activity (PubMed:28890335). Interacts with HINT1; interaction increases in the presence of calcium ions (By similarity). Interacts with HINT3 (By similarity). Interacts with GARIN2; in mature sperm flagella (By similarity).SUBUNIT (Microbial infection) Interacts with Rubella virus protease/methyltransferase p150.SUBUNIT (Microbial infection) Interacts with Legionella pneumophila glutamylase SidJ.SUBUNIT (Microbial infection) Interacts with C.violaceum CopC (PubMed:35446120, PubMed:35338844). C.violaceum CopC interacts specifically with the apo form of calmodulin (PubMed:35446120).SUBUNIT (Microbial infection) Interacts with S.flexneri OspC1 and OspC3 (PubMed:35568036). S.flexneri OspC1 and OspC3 interact specifically with the apo form of calmodulin and prevents calcium-binding (PubMed:35568036).DOMAIN The N-terminal and C-terminal lobes of CALM bind to the C-terminus of KCNQ1 in a clamp-like conformation. Binding of CALM C-terminus to KCNQ1 is calcium-independent but is essential for assembly of the structure. Binding of CALM N-terminus to KCNQ1 is calcium-dependent and regulates electrophysiological activity of the channel.PTM Ubiquitination results in a strongly decreased activity.PTM Phosphorylation results in a decreased activity.MISCELLANEOUS This protein has four functional calcium-binding sites.SIMILARITY Belongs to the calmodulin family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref158">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P0DP23</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature10">
+    <bp:featureLocation rdf:resource="#SequenceInterval10" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval10">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite27" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite28" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite27">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite28">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">149</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref159">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9016707</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=9016707</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref160">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-9016707</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-9016707.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry25">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein10" />
+  </bp:Stoichiometry>
+  <bp:SmallMolecule rdf:ID="SmallMolecule26">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ca2+</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calcium</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">calcium(2+)</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference26" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 74016</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref162" />
+    <bp:xref rdf:resource="#UnificationXref163" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref27" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference26">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">calcium(2+) [ChEBI:29108]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">calcium(2+)</bp:name>
+    <bp:xref rdf:resource="#UnificationXref161" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref161">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:29108</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref162">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">74016</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=74016</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref163">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-74016</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-74016.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref27">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00076</bp:id>
+  </bp:RelationshipXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry26">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">4</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule26" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref164">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">74294</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=74294</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref165">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-74294</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-74294.3</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry27">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex11" />
+  </bp:Stoichiometry>
+  <bp:Protein rdf:ID="Protein11">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSP90</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSP90AA1</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference9" />
+    <bp:feature rdf:resource="#FragmentFeature11" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 192864</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref167" />
+    <bp:xref rdf:resource="#UnificationXref168" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference9">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P07900 HSP90AA1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSP90AA1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSP90A</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSPC1</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSPCA</bp:name>
+    <bp:xref rdf:resource="#UnificationXref166" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Molecular chaperone that promotes the maturation, structural maintenance and proper regulation of specific target proteins involved for instance in cell cycle control and signal transduction. Undergoes a functional cycle that is linked to its ATPase activity which is essential for its chaperone activity. This cycle probably induces conformational changes in the client proteins, thereby causing their activation. Interacts dynamically with various co-chaperones that modulate its substrate recognition, ATPase cycle and chaperone function (PubMed:11274138, PubMed:15577939, PubMed:15937123, PubMed:27353360, PubMed:29127155, PubMed:12526792). Engages with a range of client protein classes via its interaction with various co-chaperone proteins or complexes, that act as adapters, simultaneously able to interact with the specific client and the central chaperone itself (PubMed:29127155). Recruitment of ATP and co-chaperone followed by client protein forms a functional chaperone. After the completion of the chaperoning process, properly folded client protein and co-chaperone leave HSP90 in an ADP-bound partially open conformation and finally, ADP is released from HSP90 which acquires an open conformation for the next cycle (PubMed:27295069, PubMed:26991466). Plays a critical role in mitochondrial import, delivers preproteins to the mitochondrial import receptor TOMM70 (PubMed:12526792). Apart from its chaperone activity, it also plays a role in the regulation of the transcription machinery. HSP90 and its co-chaperones modulate transcription at least at three different levels (PubMed:25973397). In the first place, they alter the steady-state levels of certain transcription factors in response to various physiological cues(PubMed:25973397). Second, they modulate the activity of certain epigenetic modifiers, such as histone deacetylases or DNA methyl transferases, and thereby respond to the change in the environment (PubMed:25973397). Third, they participate in the eviction of histones from the promoter region of certain genes and thereby turn on gene expression (PubMed:25973397). Binds bacterial lipopolysaccharide (LPS) and mediates LPS-induced inflammatory response, including TNF secretion by monocytes (PubMed:11276205). Antagonizes STUB1-mediated inhibition of TGF-beta signaling via inhibition of STUB1-mediated SMAD3 ubiquitination and degradation (PubMed:24613385). Mediates the association of TOMM70 with IRF3 or TBK1 in mitochondrial outer membrane which promotes host antiviral response (PubMed:20628368, PubMed:25609812).FUNCTION (Microbial infection) Seems to interfere with N.meningitidis NadA-mediated invasion of human cells. Decreasing HSP90 levels increases adhesion and entry of E.coli expressing NadA into human Chang cells; increasing its levels leads to decreased adhesion and invasion.ACTIVITY REGULATION In the resting state, through the dimerization of its C-terminal domain, HSP90 forms a homodimer which is defined as the open conformation (PubMed:18400751). Upon ATP-binding, the N-terminal domain undergoes significant conformational changes and comes in contact to form an active closed conformation (PubMed:18400751). After HSP90 finishes its chaperoning tasks of assisting the proper folding, stabilization and activation of client proteins under the active state, ATP molecule is hydrolyzed to ADP which then dissociates from HSP90 and directs the protein back to the resting state (PubMed:18400751). Co-chaperone TSC1 promotes ATP binding and inhibits HSP90AA1 ATPase activity (PubMed:29127155). Binding to phosphorylated AHSA1 promotes HSP90AA1 ATPase activity (PubMed:29127155). Inhibited by geldanamycin, Ganetespib (STA-9090) and SNX-2112 (PubMed:29127155, PubMed:12526792).SUBUNIT Homodimer (PubMed:7588731, PubMed:8289821, PubMed:18400751, PubMed:29127155). Identified in NR3C1/GCR steroid receptor-chaperone complexes formed at least by NR3C1, HSP90AA1 and a variety of proteins containing TPR repeats such as FKBP4, FKBP5, PPID, PPP5C or STIP1 (PubMed:15383005, PubMed:9195923). Forms a complex containing HSP90AA1, TSC1 and TSC2; TSC1 is required to recruit TCS2 to the complex (PubMed:29127155). The closed form interacts (via the middle domain and TPR repeat-binding motif) with co-chaperone TSC1 (via C-terminus) (PubMed:29127155). Interacts with TOM34 (PubMed:9660753). Interacts with TERT; the interaction, together with PTGES3, is required for correct assembly and stabilization of the TERT holoenzyme complex (PubMed:11274138, PubMed:9817749). Interacts with CHORDC1 and DNAJC7 (PubMed:12853476, PubMed:19875381). Interacts with STUB1 and UBE2N; may couple the chaperone and ubiquitination systems (PubMed:16307917, PubMed:27353360). Interacts (via TPR repeat-binding motif) with PPP5C (via TPR repeats); the interaction is direct and activates PPP5C phosphatase activity (PubMed:15383005, PubMed:15577939, PubMed:16531226, PubMed:27353360). Following LPS binding, may form a complex with CXCR4, GDF5 and HSPA8 (PubMed:11276205). Interacts with KSR1 (PubMed:10409742). Interacts with co-chaperone CDC37 (via C-terminus); the interaction inhibits HSP90AA1 ATPase activity (PubMed:23569206, PubMed:27353360). May interact with NWD1 (PubMed:24681825). Interacts with FNIP1 and FNIP2; the interaction inhibits HSP90AA1 ATPase activity (PubMed:17028174, PubMed:27353360). Interacts with co-chaperone AHSA1 (phosphorylated on 'Tyr-223'); the interaction activates HSP90AA1 ATPase activity and results in the dissociation of TSC1 from HSP90AA1 (PubMed:12604615, PubMed:27353360, PubMed:29127155). Interacts with FLCN in the presence of FNIP1 (PubMed:27353360). Interacts with HSP70, STIP1 and PTGES3 (PubMed:27353360). Interacts with SMYD3; this interaction enhances SMYD3 histone-lysine N-methyltransferase (PubMed:15235609, PubMed:25738358). Interacts with SGTA (via TPR repeats) (PubMed:15708368). Interacts with TTC1 (via TPR repeats) (PubMed:15708368). Interacts with HSF1 in an ATP-dependent manner (PubMed:11583998. PubMed:26517842). Interacts with MET; the interaction suppresses MET kinase activity (PubMed:26517842). Interacts with ERBB2 in an ATP-dependent manner; the interaction suppresses ERBB2 kinase activity (PubMed:26517842). Interacts with HIF1A, KEAP1 and RHOBTB2 (PubMed:26517842). Interacts with HSF1; this interaction is decreased in a IER5-dependent manner, promoting HSF1 accumulation in the nucleus, homotrimerization and DNA-binding activities (PubMed:26754925). Interacts with STUB1 and SMAD3 (PubMed:24613385). Interacts with HSP90AB1; interaction is constitutive (PubMed:20353823). Interacts with HECTD1 (via N-terminus) (By similarity). Interacts with NR3C1 (via domain NR LBD) and NR1D1 (via domain NR LBD) (By similarity). Interacts with NLPR12 (PubMed:30559449, PubMed:17947705). Interacts with PDCL3 (By similarity). Interacts with TOMM70; the interaction is required for preprotein mitochondrial import (PubMed:12526792). Interacts with TOMM70, IRF3 and TBK1; the interactions are direct and mediate the association of TOMM70 with IRF3 and TBK1 (PubMed:20628368). Forms a complex with ASL, ASS1 and NOS2; the complex regulates cell-autonomous L-arginine synthesis and citrulline recycling while channeling extracellular L-arginine to nitric oxide synthesis pathway.SUBUNIT (Microbial infection) Interacts with herpes simplex virus 1 protein US11; this interaction inhibits TBK1-induced interferon production.SUBUNIT (Microbial infection) Interacts with N.meningitidis serogroup B adhesin A (nadA). Interaction is stabilized by ADP and 17-AAG (17-N-allylamino-17-demethoxygeldanamycin) and inhibited by ATP. Decreasing HSP90 levels increases adhesion and entry of bacterial into human Chang cells; increasing its levels leads to decreased adhseion and invasion.DOMAIN The TPR repeat-binding motif mediates interaction with TPR repeat-containing proteins like the co-chaperone STUB1.PTM ISGylated.PTM S-nitrosylated; negatively regulates the ATPase activity and the activation of eNOS by HSP90AA1.PTM Ubiquitinated via 'Lys-63'-linked polyubiquitination by HECTD1. Ubiquitination promotes translocation into the cytoplasm away from the membrane and secretory pathways.SIMILARITY Belongs to the heat shock protein 90 family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref166">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P07900</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature11">
+    <bp:featureLocation rdf:resource="#SequenceInterval11" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval11">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite29" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite30" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite29">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite30">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">732</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref167">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">192864</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=192864</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref168">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-192864</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-192864.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry28">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein11" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref169">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">202121</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=202121</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref170">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-202121</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-202121.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Complex rdf:ID="Complex12">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S1177-eNOS:CaM:HSP90:p-AKT1:BH4</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary2" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry29" />
+    <bp:component rdf:resource="#SmallMolecule6" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry30" />
+    <bp:component rdf:resource="#Complex9" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497830</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref171" />
+    <bp:xref rdf:resource="#UnificationXref172" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Stoichiometry rdf:ID="Stoichiometry29">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule6" />
+  </bp:Stoichiometry>
+  <bp:Stoichiometry rdf:ID="Stoichiometry30">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex9" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref171">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497830</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497830</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref172">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497830</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497830.2</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref173">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497784</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497784</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref174">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497784</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497784.2</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref17">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">19583767</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2009</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Structural and mechanistic aspects of flavoproteins: electron transfer through the nitric oxide synthase flavoprotein domain</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stuehr, DJ</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tejero, J</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haque, MM</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FEBS J 276:3959-74</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep12">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction12" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction13">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#Complex12" />
+    <bp:left rdf:resource="#SmallMolecule22" />
+    <bp:right rdf:resource="#Complex13" />
+    <bp:right rdf:resource="#SmallMolecule6" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BH2 binding can lead to eNOS uncoupling</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref177" />
+    <bp:xref rdf:resource="#UnificationXref178" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The oxidation product of BH4, 7,8-dihydrobiopterin (BH2), can compete with BH4 for binding to eNOS. This can lead to the uncoupling of eNOS and can result in the formation of reactive oxygen species (Vasquez-Vivar et al. 2002).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref18" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:Complex rdf:ID="Complex13">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p-S1177-eNOS:CaM:HSP90:p-AKT1:BH2</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary2" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry31" />
+    <bp:component rdf:resource="#Complex10" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry32" />
+    <bp:component rdf:resource="#Protein9" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry33" />
+    <bp:component rdf:resource="#Complex11" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry34" />
+    <bp:component rdf:resource="#SmallMolecule22" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry35" />
+    <bp:component rdf:resource="#Protein11" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497889</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref175" />
+    <bp:xref rdf:resource="#UnificationXref176" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Stoichiometry rdf:ID="Stoichiometry31">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex10" />
+  </bp:Stoichiometry>
+  <bp:Stoichiometry rdf:ID="Stoichiometry32">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein9" />
+  </bp:Stoichiometry>
+  <bp:Stoichiometry rdf:ID="Stoichiometry33">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex11" />
+  </bp:Stoichiometry>
+  <bp:Stoichiometry rdf:ID="Stoichiometry34">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#SmallMolecule22" />
+  </bp:Stoichiometry>
+  <bp:Stoichiometry rdf:ID="Stoichiometry35">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">1</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein11" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref175">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497889</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497889</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref176">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497889</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497889.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref177">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497796</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497796</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref178">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497796</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497796.2</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref18">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">11879202</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2002</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The ratio between tetrahydrobiopterin and oxidized tetrahydrobiopterin analogues controls superoxide release from endothelial nitric oxide synthase: an EPR spin trapping study</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vásquez-Vivar, J</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Martasek, P</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Whitsett, J</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Joseph, Jacob</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kalyanaraman, B</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biochem J 362:733-9</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep13">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction13" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction14">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:participantStoichiometry rdf:resource="#Stoichiometry36" />
+    <bp:left rdf:resource="#Complex4" />
+    <bp:left rdf:resource="#Complex1" />
+    <bp:right rdf:resource="#Complex3" />
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCHFR binds to GCH1 and negatively regulates its activity</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref179" />
+    <bp:xref rdf:resource="#UnificationXref180" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High levels of the end product, BH4, negatively regulates GCH1. It does this via GTP cyclohydrolase 1 feedback regulatory protein (GCHFR). BH4-dependant GCHFR in the form of a homopentamer complexes with the decameric GCH1 enzyme in the ratio 2:1 to inactivate it. L-phenylalanine reverses this inhibition. These regulatory steps control the biosynthesis of BH4. (Swick &amp; Kapatos 2006, Chavan et al. 2006, Harada et al. 1993).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref19" />
+    <bp:xref rdf:resource="#PublicationXref20" />
+    <bp:xref rdf:resource="#PublicationXref21" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:Stoichiometry rdf:ID="Stoichiometry36">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Complex4" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref179">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474158</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474158</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref180">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474158</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474158.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref19">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">16696853</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2006</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A yeast 2-hybrid analysis of human GTP cyclohydrolase I protein interactions</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Swick, L</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kapatos, G</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Neurochem 97:1447-55</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref20">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">8502995</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1993</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Feedback regulation mechanisms for the control of GTP cyclohydrolase I activity</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Harada, T</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kagamiyama, H</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hatakeyama, K</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Science 260:1507-10</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref21">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">16778797</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2006</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GTP cyclohydrolase feedback regulatory protein controls cofactor 6-tetrahydrobiopterin synthesis in the cytosol and in the nucleus of epidermal keratinocytes and melanocytes</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chavan, B</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gillbro, JM</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rokos, H</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schallreuter, KU</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Invest Dermatol 126:2481-9</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep14">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction14" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction15">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule14" />
+    <bp:left rdf:resource="#SmallMolecule27" />
+    <bp:left rdf:resource="#SmallMolecule12" />
+    <bp:right rdf:resource="#SmallMolecule22" />
+    <bp:right rdf:resource="#SmallMolecule13" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.1.1.153</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Salvage - Sepiapterin is reduced to BH2</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref184" />
+    <bp:xref rdf:resource="#UnificationXref185" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In the first of two salvage steps to maintain BH4 levels in the cell, sepiapterin is taken up by the cell and reduced by sepiapterin reductase (SRP) to form BH2 (Sawabe et al. 2008).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref22" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:SmallMolecule rdf:ID="SmallMolecule27">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">H+</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proton</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hydron</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#SmallMoleculeReference27" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 70106</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref182" />
+    <bp:xref rdf:resource="#UnificationXref183" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:xref rdf:resource="#RelationshipXref28" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:ID="SmallMoleculeReference27">
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hydron [ChEBI:15378]</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hydron</bp:name>
+    <bp:xref rdf:resource="#UnificationXref181" />
+  </bp:SmallMoleculeReference>
+  <bp:UnificationXref rdf:ID="UnificationXref181">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ChEBI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHEBI:15378</bp:id>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref182">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">70106</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=70106</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref183">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-ALL-70106</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-ALL-70106.4</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref28">
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary1" />
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMPOUND</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C00080</bp:id>
+  </bp:RelationshipXref>
+  <bp:Catalysis rdf:ID="Catalysis7">
+    <bp:controller rdf:resource="#Complex8" />
+    <bp:controlled rdf:resource="#BiochemicalReaction15" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref17" />
+    <bp:xref rdf:resource="#RelationshipXref18" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:UnificationXref rdf:ID="UnificationXref184">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497869</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497869</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref185">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497869</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497869.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref22">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">18511317</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2008</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cellular uptake of sepiapterin and push-pull accumulation of tetrahydrobiopterin</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sawabe, K</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yamamoto, K</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Harada, Y</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ohashi, A</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sugawara, Y</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Matsuoka, H</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hasegawa, H</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mol Genet Metab 94:410-6</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep15">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction15" />
+    <bp:nextStep rdf:resource="#PathwayStep16" />
+    <bp:nextStep rdf:resource="#PathwayStep13" />
+    <bp:stepProcess rdf:resource="#Catalysis7" />
+  </bp:PathwayStep>
+  <bp:BiochemicalReaction rdf:ID="BiochemicalReaction16">
+    <bp:conversionDirection rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LEFT-TO-RIGHT</bp:conversionDirection>
+    <bp:left rdf:resource="#SmallMolecule27" />
+    <bp:left rdf:resource="#SmallMolecule22" />
+    <bp:left rdf:resource="#SmallMolecule12" />
+    <bp:right rdf:resource="#SmallMolecule6" />
+    <bp:right rdf:resource="#SmallMolecule13" />
+    <bp:eCNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.5.1.3</bp:eCNumber>
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Salvage - BH2 is reduced to BH4 by DHFR</bp:displayName>
+    <bp:xref rdf:resource="#UnificationXref191" />
+    <bp:xref rdf:resource="#UnificationXref192" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In the second salvage step, dihydrofolate reductase (DHFR) can regenerate BH4 from BH2, a process which increases the BH4:BH2 ratio providing BH4 for coupled eNOS production of NO. In mice cell lines, DHFR inhibition or knockdown diminishes the BH4:BH2 ratio and exacerbates eNOS uncoupling (Crabtree et al. 2009).</bp:comment>
+    <bp:xref rdf:resource="#PublicationXref23" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Authored: Jassal, B, 2011-08-17</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reviewed: D'Eustachio, P, 2011-08-23</bp:comment>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Edited: Jassal, B, 2011-08-17</bp:comment>
+  </bp:BiochemicalReaction>
+  <bp:Catalysis rdf:ID="Catalysis8">
+    <bp:controller rdf:resource="#Complex14" />
+    <bp:controlled rdf:resource="#BiochemicalReaction16" />
+    <bp:controlType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+    <bp:xref rdf:resource="#RelationshipXref29" />
+    <bp:xref rdf:resource="#RelationshipXref30" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Catalysis>
+  <bp:Complex rdf:ID="Complex14">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DHFR dimer</bp:displayName>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:componentStoichiometry rdf:resource="#Stoichiometry37" />
+    <bp:component rdf:resource="#Protein12" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 1497822</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref189" />
+    <bp:xref rdf:resource="#UnificationXref190" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Complex>
+  <bp:Protein rdf:ID="Protein12">
+    <bp:displayName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DHFR</bp:displayName>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dihydrofolate reductase</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DYR_HUMAN</bp:name>
+    <bp:cellularLocation rdf:resource="#CellularLocationVocabulary1" />
+    <bp:entityReference rdf:resource="#ProteinReference10" />
+    <bp:feature rdf:resource="#FragmentFeature12" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome DB_ID: 197984</bp:comment>
+    <bp:xref rdf:resource="#UnificationXref187" />
+    <bp:xref rdf:resource="#UnificationXref188" />
+    <bp:dataSource rdf:resource="#Provenance1" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:ID="ProteinReference10">
+    <bp:organism rdf:resource="#BioSource1" />
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt:P00374 DHFR</bp:name>
+    <bp:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DHFR</bp:name>
+    <bp:xref rdf:resource="#UnificationXref186" />
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FUNCTION Key enzyme in folate metabolism. Contributes to the de novo mitochondrial thymidylate biosynthesis pathway. Catalyzes an essential reaction for de novo glycine and purine synthesis, and for DNA precursor synthesis. Binds its own mRNA and that of DHFR2.PATHWAY Cofactor biosynthesis; tetrahydrofolate biosynthesis; 5,6,7,8-tetrahydrofolate from 7,8-dihydrofolate: step 1/1.SUBUNIT Homodimer.TISSUE SPECIFICITY Widely expressed in fetal and adult tissues, including throughout the fetal and adult brains and whole blood. Expression is higher in the adult brain than in the fetal brain.SIMILARITY Belongs to the dihydrofolate reductase family.</bp:comment>
+  </bp:ProteinReference>
+  <bp:UnificationXref rdf:ID="UnificationXref186">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProt</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P00374</bp:id>
+  </bp:UnificationXref>
+  <bp:FragmentFeature rdf:ID="FragmentFeature12">
+    <bp:featureLocation rdf:resource="#SequenceInterval12" />
+  </bp:FragmentFeature>
+  <bp:SequenceInterval rdf:ID="SequenceInterval12">
+    <bp:sequenceIntervalBegin rdf:resource="#SequenceSite31" />
+    <bp:sequenceIntervalEnd rdf:resource="#SequenceSite32" />
+  </bp:SequenceInterval>
+  <bp:SequenceSite rdf:ID="SequenceSite31">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:SequenceSite rdf:ID="SequenceSite32">
+    <bp:sequencePosition rdf:datatype="http://www.w3.org/2001/XMLSchema#int">187</bp:sequencePosition>
+    <bp:positionStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EQUAL</bp:positionStatus>
+  </bp:SequenceSite>
+  <bp:UnificationXref rdf:ID="UnificationXref187">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">197984</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=197984</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref188">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-197984</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-197984.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:Stoichiometry rdf:ID="Stoichiometry37">
+    <bp:stoichiometricCoefficient rdf:datatype="http://www.w3.org/2001/XMLSchema#float">2</bp:stoichiometricCoefficient>
+    <bp:physicalEntity rdf:resource="#Protein12" />
+  </bp:Stoichiometry>
+  <bp:UnificationXref rdf:ID="UnificationXref189">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497822</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497822</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref190">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497822</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497822.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref29">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0004146</bp:id>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary2" />
+  </bp:RelationshipXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref30">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497819</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497819</bp:comment>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary3" />
+  </bp:RelationshipXref>
+  <bp:UnificationXref rdf:ID="UnificationXref191">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1497794</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1497794</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref192">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1497794</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1497794.1</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref23">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">19666465</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2009</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Critical role for tetrahydrobiopterin recycling by dihydrofolate reductase in regulation of endothelial nitric-oxide synthase coupling: relative importance of the de novo biopterin synthesis versus salvage pathways</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crabtree, MJ</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tatham, AL</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hale, AB</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alp, NJ</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Channon, KM</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Biol Chem 284:28128-36</bp:source>
+  </bp:PublicationXref>
+  <bp:PathwayStep rdf:ID="PathwayStep16">
+    <bp:stepProcess rdf:resource="#BiochemicalReaction16" />
+    <bp:stepProcess rdf:resource="#Catalysis8" />
+  </bp:PathwayStep>
+  <bp:UnificationXref rdf:ID="UnificationXref193">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome Database ID Release 83</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1474151</bp:id>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Database identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser?DB=gk_current&amp;ID=1474151</bp:comment>
+  </bp:UnificationXref>
+  <bp:UnificationXref rdf:ID="UnificationXref194">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R-HSA-1474151</bp:id>
+    <bp:idVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">5</bp:idVersion>
+    <bp:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reactome stable identifier. Use this URL to connect to the web page of this instance in Reactome: http://www.reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=R-HSA-1474151.5</bp:comment>
+  </bp:UnificationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref24">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10727395</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2000</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tetrahydrobiopterin biosynthesis, regeneration and functions</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thöny, B</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Auerbach, G</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Blau, N</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Biochem J 347:1-16</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref25">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">18321209</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2008</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nitric oxide, tetrahydrobiopterin, oxidative stress, and endothelial dysfunction in hypertension</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schulz, E</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jansen, T</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wenzel, P</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Daiber, A</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Münzel, T</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Antioxid Redox Signal 10:1115-26</bp:source>
+  </bp:PublicationXref>
+  <bp:PublicationXref rdf:ID="PublicationXref26">
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">17555404</bp:id>
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pubmed</bp:db>
+    <bp:year rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2007</bp:year>
+    <bp:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mechanisms for the role of tetrahydrobiopterin in endothelial function and vascular disease</bp:title>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schmidt, TS</bp:author>
+    <bp:author rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alp, NJ</bp:author>
+    <bp:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clin Sci (Lond) 113:47-63</bp:source>
+  </bp:PublicationXref>
+  <bp:RelationshipXref rdf:ID="RelationshipXref31">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GENE ONTOLOGY</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0046146</bp:id>
+    <bp:relationshipType rdf:resource="#RelationshipTypeVocabulary4" />
+  </bp:RelationshipXref>
+  <bp:RelationshipTypeVocabulary rdf:ID="RelationshipTypeVocabulary4">
+    <bp:term rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene ontology term for cellular process</bp:term>
+    <bp:xref rdf:resource="#UnificationXref195" />
+  </bp:RelationshipTypeVocabulary>
+  <bp:UnificationXref rdf:ID="UnificationXref195">
+    <bp:db rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MI</bp:db>
+    <bp:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MI:0359</bp:id>
+  </bp:UnificationXref>
+</rdf:RDF>
+


### PR DESCRIPTION
For #221.

Now we will attempt to extract CHEBI terms for _all_ SmallMolecules regardless of whether it's in a Reactome or YeastCyc pathway.

Also removed a redundant variable `reactome_entity_id ` as it's effectively the same as `entity_id `and not used anywhere else.