### PR TITLE
Infer has_small_molecule_regulator for #204

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -123,7 +123,8 @@ public class GoCAM {
 	directly_negatively_regulates, directly_positively_regulates, has_role, causally_upstream_of, causally_upstream_of_negative_effect, causally_upstream_of_positive_effect,
 	negatively_regulates, positively_regulates, 
 	has_target_end_location, has_target_start_location, interacts_with, has_participant, functionally_related_to,
-	contributes_to, only_in_taxon, transports_or_maintains_localization_of;
+	contributes_to, only_in_taxon, transports_or_maintains_localization_of,
+	has_small_molecule_inhibitor, has_small_molecule_activator;
 	public static OWLDataProperty has_start, has_end;
 
 	public static OWLClass 
@@ -366,6 +367,8 @@ public class GoCAM {
 		has_target_start_location = df.getOWLObjectProperty(IRI.create(obo_iri + "RO_0002338"));
 		contributes_to = df.getOWLObjectProperty(IRI.create(obo_iri + "RO_0002326"));
 		transports_or_maintains_localization_of = df.getOWLObjectProperty(IRI.create(obo_iri + "RO_0002313"));
+		has_small_molecule_inhibitor = df.getOWLObjectProperty(IRI.create(obo_iri + "RO_0012002"));
+		has_small_molecule_activator = df.getOWLObjectProperty(IRI.create(obo_iri + "RO_0012001"));
 		//re-usable restrictions
 		taxon_human = df.getOWLObjectSomeValuesFrom(only_in_taxon, human);
 		//data properties
@@ -971,8 +974,8 @@ final long counterValue = instanceCounter.getAndIncrement();
 		r = inferRegulatesViaOutputEnables(model_id, r);
 		logger.debug("inferring provides input for");
 		r = inferProvidesInput(model_id, r);
-		logger.debug("converting entity regulators to (not)binding events");
-		r = convertEntityRegulatorsToBindingFunctions(model_id, r);
+		logger.debug("inferring small molecule regulators");
+		r = inferSmallMoleculeRegulators(model_id, r, tbox_qrunner);
 		logger.debug("deleting complexes with active units");
 		deleteComplexesWithActiveUnits();
 		logger.debug("deleting disallowed relations like that between a non-gene product molecular and the reaction it regulates");		
@@ -1378,7 +1381,7 @@ For reactions with multiple entity locations and no enabler, do not assign any o
 		return r;
 	}
 
-
+	
 	/**
 	 * Rule: entity involved in regulation of function 
 Binding has_input E1
@@ -1475,6 +1478,93 @@ BP has_part R
 					if(pathway!=null) {
 						addRefBackedObjectPropertyAssertion(bp_node, regulator_prop, pathway, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);					
 					}
+					//delete the original entity regulates process relation 
+					applyAnnotatedTripleRemover(regulator.getIRI(), prop_for_deletion.getIRI(), reaction.getIRI());
+				}
+			}
+		}
+		r.rule_hitcount.put(entity_regulator_rule, entity_regulator_count);
+		r.rule_pathways.put(entity_regulator_rule, entity_regulator_pathways);
+		qrunner = new QRunner(go_cam_ont); 
+		return r;
+	}
+	
+
+	/**
+	 * Rule: entity involved in regulation of function 
+Binding has_input E1
+Binding has_input E2
+Binding +-_regulates R
+Binding part_of +-_regulation_of BP
+⇐ 	
+E1 +- involved_in_regulation_of R
+R enabled_by E2
+BP has_part R
+	 * @return 
+	 */
+	private RuleResults inferSmallMoleculeRegulators(String model_id, RuleResults r, QRunner tbox_qrunner) {		
+		String entity_regulator_rule = "Entity Regulator Rule";
+		Integer entity_regulator_count = r.checkInitCount(entity_regulator_rule, r);
+		Set<String> entity_regulator_pathways = r.checkInitPathways(entity_regulator_rule, r);
+		Set<InferredRegulator> ers = qrunner.getInferredAnonymousRegulators();
+
+		Map<String, Set<InferredRegulator>> reaction_regulators = new HashMap<String, Set<InferredRegulator>>();
+		for(InferredRegulator er : ers) {
+			Set<InferredRegulator> reg = reaction_regulators.get(er.reaction1_uri);
+			if(reg == null) {
+				reg = new HashSet<InferredRegulator>();
+			}
+			reg.add(er);
+			reaction_regulators.put(er.reaction1_uri, reg);
+		}
+
+		entity_regulator_count+=ers.size();
+		String obo_base ="http://purl.obolibrary.org/obo/";
+		OWLClass chebi_chemical = df.getOWLClass(IRI.create(obo_base+"CHEBI_24431"));
+		OWLClass chebi_nucleic_acid = df.getOWLClass(IRI.create(obo_base+"CHEBI_33696"));
+		for(String reaction_uri : reaction_regulators.keySet()) {
+			OWLNamedIndividual reaction = makeUnannotatedIndividual(reaction_uri);
+			//just do this once per reaction, most is redundant because of flat response structure
+			Set<InferredRegulator> regs = reaction_regulators.get(reaction_uri);
+			if(!regs.isEmpty()) {
+				InferredRegulator base = regs.iterator().next();
+				OWLNamedIndividual pathway = null;
+				if(base.pathway_uri!=null) {
+					entity_regulator_pathways.add(base.pathway_uri);
+					pathway = makeUnannotatedIndividual(base.pathway_uri);
+				}
+				//now get the actual regulating entities
+				Set<String> regulating_entities = new HashSet<String>();
+				for(InferredRegulator er : reaction_regulators.get(reaction_uri)) {
+					OWLClass entity_type_class = this.df.getOWLClass(IRI.create(er.entity_type_uri));
+					Set<OWLClass> entity_types = tbox_qrunner.getSuperClasses(entity_type_class, false);
+					//Only do this for chemical entities but not if nucleic acid or descendant
+					if(!entity_types.contains(chebi_chemical) || entity_types.contains(chebi_nucleic_acid)) {
+						continue;
+					}
+					//catch cases where there may be more than one of the same entity
+					//avoid making multiple redundant binding functions for the same entity
+					if(!regulating_entities.add(er.entity_uri)) {
+						continue;
+					}
+					Set<OWLAnnotation> annos = getDefaultAnnotations();
+					OWLNamedIndividual regulator = makeUnannotatedIndividual(er.entity_uri);
+
+					OWLObjectProperty prop_for_deletion = GoCAM.involved_in_negative_regulation_of;
+					OWLObjectProperty regulator_prop = GoCAM.has_small_molecule_inhibitor;
+					String explain = "Entity Regulator Rule.  The relation was added to account for an assertion about an entity regulating the target reaction.";
+					if(er.prop_uri.equals("http://purl.obolibrary.org/obo/RO_0002429")) {
+						//String reg = " is involved in positive regulation of ";
+						annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(explain)));
+						prop_for_deletion = GoCAM.involved_in_positive_regulation_of;
+						regulator_prop = GoCAM.has_small_molecule_activator;
+					}else {
+						//String reg = " is involved in negative regulation of ";
+						annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(explain)));
+					}
+					//Connect the regulator to reaction via has_small_molecule_... relation
+					addRefBackedObjectPropertyAssertion(reaction, regulator_prop, regulator, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);
+					
 					//delete the original entity regulates process relation 
 					applyAnnotatedTripleRemover(regulator.getIRI(), prop_for_deletion.getIRI(), reaction.getIRI());
 				}

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/QRunner.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/QRunner.java
@@ -565,12 +565,13 @@ select ?reaction2 obo:RO_0002333 ?input   # for update
 			Resource reaction = qs.getResource("reaction"); 
 			Resource property = qs.getResource("prop");
 			Resource regulator = qs.getResource("regulator");
+			Resource regulator_type = qs.getResource("regulator_type");
 			String pathway_uri = null;
 			Resource pathway = qs.getResource("pathway");			
 			if(pathway!=null) {
 				pathway_uri = pathway.getURI();
 			}
-			InferredRegulator ir = new InferredRegulator(reaction.getURI(), property.getURI(), reaction.getURI(), pathway_uri, regulator.getURI(), "");
+			InferredRegulator ir = new InferredRegulator(reaction.getURI(), property.getURI(), reaction.getURI(), pathway_uri, regulator.getURI(), regulator_type.getURI());
 			Resource enabler = qs.getResource("enabler");
 			if(enabler != null) {
 				ir.enabler_uri = enabler.getURI();

--- a/exchange/src/main/resources/org/geneontology/gocam/exchange/query2update_entity_regulation1.rq
+++ b/exchange/src/main/resources/org/geneontology/gocam/exchange/query2update_entity_regulation1.rq
@@ -15,10 +15,12 @@ prefix skos: <http://www.w3.org/2004/02/skos/core#>
 #R enabled_by E2
 #BP has_part R
 
-select ?regulator ?prop ?reaction ?pathway ?enabler 
+select ?regulator ?prop ?reaction ?pathway ?enabler ?regulator_type
 where {
    VALUES ?prop {obo:RO_0002430 obo:RO_0002429} . 
    ?regulator ?prop  ?reaction .   
+   ?regulator rdf:type ?regulator_type .
+   filter(?regulator_type != <http://www.w3.org/2002/07/owl#NamedIndividual>) .
    OPTIONAL {?reaction obo:BFO_0000050 ?pathway . }   
    OPTIONAL {?reaction obo:RO_0002333 ?enabler .  }
 }

--- a/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
+++ b/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
@@ -890,27 +890,24 @@ R enabled_by E2
 BP has_part R
 	 */
 	@Test 
-	public final void testConvertEntityRegulatorsToBindingFunctions() {
+	public final void testInferSmallMoleculeRegulators() {
 		System.out.println("Testing convert entity regulators to binding functions");
 		TupleQueryResult result = null;
 		try {
-			result = blaze.runSparqlQuery(
-				"select distinct ?binding_reaction " + 
-				"where { " + 
-				"VALUES ?reaction1 { <http://model.geneontology.org/R-HSA-71670> } ."  
-				+ " ?binding_reaction <http://purl.obolibrary.org/obo/RO_0002212> ?reaction1 . " //
-				+ "?binding_reaction rdf:type <http://purl.obolibrary.org/obo/GO_0005488> . "
-				+ "?binding_reaction <http://purl.obolibrary.org/obo/RO_0002233> ?input1 . "
-				+ "?binding_reaction <http://purl.obolibrary.org/obo/RO_0002333> ?input2 . "
-				+ "filter(?input1 != ?input2) "
-				+"}"); 
+			String query = "prefix obo: <http://purl.obolibrary.org/obo/> " +
+					"select distinct ?reg_relation ?regulator " +
+					"where { " +
+					"<http://model.geneontology.org/R-HSA-71670> ?reg_relation ?regulator . " +
+					"VALUES ?reg_relation { obo:RO_0012001 obo:RO_0012002 } . " +
+					"}";
+			result = blaze.runSparqlQuery(query);
 			int n = 0; 
 			while (result.hasNext()) {
 				BindingSet bindingSet = result.next();
-				String br = bindingSet.getValue("binding_reaction").stringValue();
+				String br = bindingSet.getValue("regulator").stringValue();
 				n++;
 			}
-			assertTrue("should have been 3, but got n results: "+n, n==3);
+			assertTrue("should have been 4, but got n results: "+n, n==4);
 		} catch (QueryEvaluationException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -922,7 +919,7 @@ BP has_part R
 				e.printStackTrace();
 			}
 		}
-		System.out.println("Done testing testConvertEntityRegulatorsToBindingFunctions");
+		System.out.println("Done testing testInferSmallMoleculeRegulators");
 	}
 	
 	/**


### PR DESCRIPTION
For #204. Replaces logic that created binding activities and regulates edges for each small molecule that had an inferred "involved in {+ | -} regulation of" relation. This now simply connects the small mol to the reaction via a "has small molecule {activator | inhibitor}" edge.

This only applies to CHEBI chemicals but not nucleic acids.