### PR TITLE
Fix null source prefix for #242

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -206,7 +206,7 @@ public class GoCAM {
 			default_namespace_prefix = "wikipathways";
 		}else if(base_provider.equals("https://www.pathwaycommons.org/")) {
 			default_namespace_prefix = "pathwaycommons";
-		}else if(base_provider.equals("https://yeastgenome.org")) {
+		}else if(base_provider.equals("http://www.yeastgenome.org")) {
 			default_namespace_prefix = "SGD";
 		}
 		

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -206,7 +206,7 @@ public class GoCAM {
 			default_namespace_prefix = "wikipathways";
 		}else if(base_provider.equals("https://www.pathwaycommons.org/")) {
 			default_namespace_prefix = "pathwaycommons";
-		}else if(base_provider.equals("https://yeastcyc.org")) {
+		}else if(base_provider.equals("https://yeastgenome.org")) {
 			default_namespace_prefix = "SGD";
 		}
 		


### PR DESCRIPTION
For #242.

This is a quick fix to just match the SGD `providedBy` value that we're using and it is consistent with [groups.yaml](https://github.com/geneontology/go-site/blob/960fcfb772bfefd2e1796ff0ee4c462fcd0dc2fb/metadata/groups.yaml#L71).