### PR TITLE
Make source URL comment more comment-like

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -278,7 +278,8 @@ public class BioPaxtoGO {
 				go_cam.path2bgjournal = blazegraph_output_journal;
 				go_cam.blazegraphdb = blaze;
 				go_cam.name = getBioPaxName(currentPathway);
-				go_cam.contributor_link = contributor_link;
+				String contrib_link_comment = "Imported from "+datasource+": "+contributor_link;
+				go_cam.contributor_link_comment = contrib_link_comment;
 			}
 			//make the OWL individual representing the pathway so it can be used below
 			OWLNamedIndividual p = go_cam.makeAnnotatedIndividual(GoCAM.makeGoCamifiedIRI(null, model_id));
@@ -286,7 +287,7 @@ public class BioPaxtoGO {
 			for(String comment : pathway_source_comments) {
 				go_cam.addComment(p, comment);
 			}
-			go_cam.addComment(p, go_cam.contributor_link);
+			go_cam.addComment(p, go_cam.contributor_link_comment);
 			//define it (add types etc)
 			definePathwayEntity(go_cam, currentPathway, model_id, expand_subpathways, add_pathway_components);	
 			//get and set parent pathways

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -153,7 +153,7 @@ public class GoCAM {
 	//for convenience
 	String name;
 	String default_namespace_prefix;
-	String contributor_link;
+	String contributor_link_comment;
 
 	public GoCAM() throws OWLOntologyCreationException {
 		ontman = OWLManager.createOWLOntologyManager();				
@@ -489,7 +489,7 @@ public class GoCAM {
 		annos.add(df.getOWLAnnotation(contributor_prop, df.getOWLLiteral(this.base_contributor)));
 		annos.add(df.getOWLAnnotation(date_prop, df.getOWLLiteral(this.base_date)));
 		annos.add(df.getOWLAnnotation(provided_by_prop, df.getOWLLiteral(this.base_provider)));
-		annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(this.contributor_link)));
+		annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(this.contributor_link_comment)));
 		return annos;
 	}
 


### PR DESCRIPTION
For #126. Adds some comment-like text "Imported from X: " to the new source URL comment.

This changes that `contributor_link` variable to `contributor_link_comment` and reuses the `datasource` var used elsewhere (in generating the model title). See comment from ticket for more detail: https://github.com/geneontology/pathways2GO/issues/126#issuecomment-1546469524