### PR TITLE
Delete non small mol regulator individuals

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -960,7 +960,7 @@ final long counterValue = instanceCounter.getAndIncrement();
 	 * @param tbox_qrunner 
 	 * @throws IOException 
 	 */
-	RuleResults applySparqlRules(String model_id, QRunner tbox_qrunner) throws IOException {
+	RuleResults applySparqlRules(String model_id, QRunner tbox_qrunner) {
 
 		RuleResults r = new RuleResults();
 		//NOTE that the order these are run matters.
@@ -1553,10 +1553,6 @@ BP has_part R
 					OWLClass entity_type_class = this.df.getOWLClass(IRI.create(er.entity_type_uri));
 					Set<OWLClass> entity_types = tbox_qrunner.getSuperClasses(entity_type_class, false);
 					entity_types.add(entity_type_class);  // Some of these are directly chebi_chemical
-					//Only do this for chemical entities but not if nucleic acid or descendant
-//					if(!entity_types.contains(chebi_chemical) || entity_types.contains(chebi_nucleic_acid)) {
-//						continue;
-//					}
 					//catch cases where there may be more than one of the same entity
 					//avoid making multiple redundant binding functions for the same entity
 					if(!regulating_entities.add(er.entity_uri)) {
@@ -1564,57 +1560,8 @@ BP has_part R
 					}
 					Set<OWLAnnotation> annos = getDefaultAnnotations();
 					OWLNamedIndividual regulator = makeUnannotatedIndividual(er.entity_uri);
-
-//					// TODO: Determine if complex: entity_type_class.getIRI().getRemainder().equals("REACTO_R-HSA-5634107")
-//					if(entity_types!=null&&(entity_types.contains(chebi_protein)||entity_types.contains(go_complex))) {
-//						OWLObjectProperty prop_for_deletion = GoCAM.involved_in_negative_regulation_of;
-//						OWLObjectProperty regulator_prop = GoCAM.negatively_regulates;
-//						String explain = "Entity Regulator Rule.  The relation was added to account for an assertion about an entity regulating the target reaction.";
-//						if(er.prop_uri.equals("http://purl.obolibrary.org/obo/RO_0002429")) {
-//							//String reg = " is involved in positive regulation of ";
-//							annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(explain)));
-//							prop_for_deletion = GoCAM.involved_in_positive_regulation_of;	
-//							regulator_prop = GoCAM.positively_regulates;
-//						}else {
-//							//String reg = " is involved in negative regulation of ";
-//							annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(explain)));
-//						}
-//						//make the MF node
-//						String reaction_unique_id = reaction.toString().replace("http://model.geneontology.org/", "").replaceAll("<", "").replaceAll(">","");
-//						String prop_id = regulator_prop.toString().replace("http://purl.obolibrary.org/obo/", "").replaceAll("<", "").replaceAll(">","");
-//						String regulator_id = regulator.toString().replace("http://model.geneontology.org/", "").replaceAll("<", "").replaceAll(">","");
-//						IRI new_mf_node_iri = makeGoCamifiedIRI(null, reaction_unique_id+"_regulator_"+prop_id+"_"+regulator_id);
-//						OWLNamedIndividual binding_node = makeAnnotatedIndividual(new_mf_node_iri);
-//						addComment(binding_node, "Produced by Entity Regulator Rule");					
-//					
-//						addRefBackedObjectPropertyAssertion(binding_node, has_input, regulator, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);
-//						addRefBackedObjectPropertyAssertion(binding_node, regulator_prop, reaction, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);
-//
-//						if(er.enabler_uri!=null) {
-//							addTypeAssertion(binding_node, binding);
-//							IRI new_enabler_node_iri = makeGoCamifiedIRI(null, reaction.toString().replace("http://model.geneontology.org/", "").replaceAll(">", "").replaceAll("<", "")+"_regulator_enabler_"+er.enabler_uri.toString().replace("http://model.geneontology.org/", "")+"_"+regulator.toString().replace("http://model.geneontology.org/", ""));						
-//							OWLNamedIndividual enabler = cloneIndividual(er.enabler_uri, model_id, true, false, false, true, new_enabler_node_iri);
-//							addRefBackedObjectPropertyAssertion(binding_node, enabled_by, enabler, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);
-//							//delete the cloned enable relation
-//							applyAnnotatedTripleRemover(reaction.getIRI(), enabled_by.getIRI(), enabler.getIRI());
-//							//just in case the enabler was double inserted as a controller
-//							applyAnnotatedTripleRemover(enabler.getIRI(), prop_for_deletion.getIRI(), reaction.getIRI());
-//							applyAnnotatedTripleRemover(IRI.create(er.enabler_uri), prop_for_deletion.getIRI(), reaction.getIRI());
-//						}else {
-//							addTypeAssertion(binding_node, molecular_event);
-//						}
-//						//make a BP node
-//						IRI new_bp_node_iri = makeGoCamifiedIRI(null, reaction_unique_id+"_regulator_bp_"+prop_id+"_"+regulator_id);
-//						OWLNamedIndividual bp_node = makeAnnotatedIndividual(new_bp_node_iri);
-//						addComment(bp_node, "Produced by Entity Regulator Rule");
-//						addTypeAssertion(bp_node, bp_class);
-//						addRefBackedObjectPropertyAssertion(binding_node, part_of, bp_node, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);
-//						if(pathway!=null) {
-//							addRefBackedObjectPropertyAssertion(bp_node, regulator_prop, pathway, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);					
-//						}
-//						//delete the original entity regulates process relation 
-//						applyAnnotatedTripleRemover(regulator.getIRI(), prop_for_deletion.getIRI(), reaction.getIRI());
-//					}else if(entity_types.contains(chebi_chemical) && !entity_types.contains(chebi_nucleic_acid)) {
+					
+					//Only do this for chemical entities but not if nucleic acid or descendant
 					if(entity_types.contains(chebi_chemical) && !entity_types.contains(chebi_nucleic_acid)) {
 						OWLObjectProperty prop_for_deletion = GoCAM.involved_in_negative_regulation_of;
 						OWLObjectProperty regulator_prop = GoCAM.has_small_molecule_inhibitor;


### PR DESCRIPTION
For #237.

Adds an `else` block to handle deleting non-small molecule individuals from inferred regulatory reactions that were updated via #204.