### PR TITLE
Update SGD prefix in source to SGD_PWY for #254

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -184,7 +184,7 @@ public class BioPaxtoGO {
 			default_namespace_prefix = "pathwaycommons";
 		}else if(base_provider.equals("http://www.yeastgenome.org")) {
 			datasource = "Saccharomyces Genome Database";
-			default_namespace_prefix = "SGD";
+			default_namespace_prefix = "SGD_PWY";
 		}
 		//will determine how classes for physical entities are handled
 		if(entityStrategy.equals(EntityStrategy.YeastCyc)) {

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -208,7 +208,7 @@ public class GoCAM {
 		}else if(base_provider.equals("https://www.pathwaycommons.org/")) {
 			default_namespace_prefix = "pathwaycommons";
 		}else if(base_provider.equals("http://www.yeastgenome.org")) {
-			default_namespace_prefix = "SGD";
+			default_namespace_prefix = "SGD_PWY";
 		}
 		
 		//TODO find a better way


### PR DESCRIPTION
For #254.

Pretty straightforward change. I generated/loaded a test model and confirmed `SGD_PWY:{pathway_id}` was set in each evidence `source` field:
![image](https://github.com/geneontology/pathways2GO/assets/2678599/dfdbdf27-db83-45a0-992d-7605713d8750)
