### PR TITLE
Prevent emitting entities if drug

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -417,6 +417,9 @@ public class BioPaxtoGO {
 				}
 			}
 		}
+		if (id!=null) {
+			id = id.replace(" ", "_");
+		}
 		return id;
 	}
 

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -340,7 +340,11 @@ public class BioPaxtoGO {
 		String id = null;
 		Set<Xref> references = null;
 		//first check for entity reference
-		if((entityStrategy.equals(EntityStrategy.YeastCyc) && bp_entity instanceof SimplePhysicalEntity)
+		boolean is_drug = PhysicalEntityOntologyBuilder.getDrugReferenceId(bp_entity) != null;
+		if(is_drug) {
+			references = bp_entity.getXref();
+		}
+		else if((entityStrategy.equals(EntityStrategy.YeastCyc) && bp_entity instanceof SimplePhysicalEntity)
 				|| bp_entity instanceof SmallMolecule) {
 			SimplePhysicalEntity entity = (SimplePhysicalEntity) bp_entity;
 			EntityReference entity_ref = entity.getEntityReference();
@@ -357,16 +361,28 @@ public class BioPaxtoGO {
 		}
 		if(entityStrategy.equals(EntityStrategy.REACTO)) {
 			for(Xref ref : references) {
-				if(ref.getModelInterface().equals(UnificationXref.class)) {
-					UnificationXref r = (UnificationXref)ref;	    			
-					if(r.getDb().equals("Reactome")) {
-						id = r.getId();
-						if(id.startsWith("R-")) {
+				if (is_drug) {
+					if (ref.getModelInterface().equals(RelationshipXref.class)) {
+						RelationshipXref r = (RelationshipXref)ref;
+						if(r.getDb().equalsIgnoreCase("ChEBI")) {
+							// "CHEBI:" not included in id for these
+							id = "CHEBI_" + r.getId();
 							break;
 						}
-					}else if(r.getDb().equalsIgnoreCase("ChEBI") && bp_entity instanceof SmallMolecule) {
-						id = r.getId().replace(":", "_");
-						break;
+					}
+				}
+				else {
+					if(ref.getModelInterface().equals(UnificationXref.class)) {
+						UnificationXref r = (UnificationXref)ref;	    			
+						if(r.getDb().equals("Reactome")) {
+							id = r.getId();
+							if(id.startsWith("R-")) {
+								break;
+							}
+						}else if(r.getDb().equalsIgnoreCase("ChEBI") && bp_entity instanceof SmallMolecule) {
+							id = r.getId().replace(":", "_");
+							break;
+						}
 					}
 				}
 			}
@@ -1406,6 +1422,9 @@ public class BioPaxtoGO {
 									}
 								}
 							}
+						}
+						if (drop_drug_reactions && drug_process_ids.contains(entity_id)) {
+							continue;
 						}
 						//this is the non-recursive part.. (and we usually aren't recursing anyway)
 						IRI iri = null;

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/Biopax2GOCmdLine.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/Biopax2GOCmdLine.java
@@ -86,6 +86,7 @@ public class Biopax2GOCmdLine {
 		options.addOption("c", true, "Catalog file for tbox");
 		options.addOption("nosplit", false, "If present, do not split the input biopax file into its constituent pathways where one pathway becomes one go-cam model.  Make one big model.");
 		options.addOption("sssom", true, "An sssom formatted mapping file (optional). Will be used to add guessed classes if none are present in the biopax");
+		options.addOption("include_drug_rxns", false, "If present, drug reactions will not be included in the produced model");
 
 		CommandLineParser parser = new DefaultParser();
 		CommandLine cmd = parser.parse( options, args);
@@ -179,6 +180,10 @@ public class Biopax2GOCmdLine {
 				bp2g.add_neighboring_events_from_other_pathways = true;
 			}else {
 				bp2g.split_by_pathway = true;
+			}
+			if(cmd.hasOption("include_drug_rxns")) {
+				// drop_drug_reactions is true by default
+				bp2g.drop_drug_reactions = false;
 			}
 			if(cmd.hasOption("sssom")) {
 				bp2g.sssom = new SSSOM(cmd.getOptionValue("sssom"));


### PR DESCRIPTION
For #264.

This stops emitting entities earlier in the conversion process once it's detected they are drugs.

This code was used to generate the latest Reactome 85 load to noctua-dev in https://github.com/geneontology/noctua-models/pull/254. 