### PR TITLE
Remove explicit causal relation if rxns connected via same input/output instance

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -38,6 +38,7 @@ import org.biopax.paxtools.model.level3.Xref;
 import org.geneontology.gocam.exchange.QRunner.BindingInput;
 import org.geneontology.gocam.exchange.QRunner.ComplexInput;
 import org.geneontology.gocam.exchange.QRunner.InferredEnabler;
+import org.geneontology.gocam.exchange.QRunner.InferredInputRegulator;
 import org.geneontology.gocam.exchange.QRunner.InferredOccursIn;
 import org.geneontology.gocam.exchange.QRunner.InferredRegulator;
 import org.geneontology.gocam.exchange.QRunner.InferredTransport;
@@ -977,8 +978,8 @@ final long counterValue = instanceCounter.getAndIncrement();
 		r = inferRegulatesViaOutputRegulates(model_id, r); //must be run before convertEntityRegulatorsToBindingFunctions		
 		logger.debug("inferring regulates from output enables");
 		r = inferRegulatesViaOutputEnables(model_id, r);
-		logger.debug("inferring provides input for then removing causal relation");
-		r = inferProvidesInputRemoveCausalRelation(model_id, r);
+		logger.debug("inferring provides input for");
+		r = inferProvidesInput(model_id, r);
 		logger.debug("inferring small molecule regulators");
 		r = inferSmallMoleculeRegulators(model_id, r, tbox_qrunner);
 		logger.debug("deleting complexes with active units");
@@ -1374,45 +1375,25 @@ For reactions with multiple entity locations and no enabler, do not assign any o
 		Integer provides_input_count = r.checkInitCount(provides_input_rule, r);
 		Set<String> provides_input_pathways = r.checkInitPathways(provides_input_rule, r);
 
-		Set<InferredRegulator> provides_input = qrunner.getInferredInputProviders();
+		Set<InferredInputRegulator> provides_input = qrunner.getInferredInputProviders();
 		provides_input_count+=provides_input.size();
-		for(InferredRegulator ir : provides_input) {
+		for(InferredInputRegulator ir : provides_input) {
 			provides_input_pathways.add(ir.pathway_uri);
 			//create ?reaction2 obo:RO_0002333 ?input
 			OWLNamedIndividual r1 = this.makeAnnotatedIndividual(ir.reaction1_uri);
 			OWLNamedIndividual r2 = this.makeAnnotatedIndividual(ir.reaction2_uri);
-			OWLObjectProperty o = df.getOWLObjectProperty(IRI.create(ir.prop_uri));
-			String r1_label = "'"+this.getaLabel(r1)+"'";
-			String r2_label = "'"+this.getaLabel(r2)+"'";
-			String o_label = "'"+this.getaLabel(o)+"'";
-			Set<OWLAnnotation> annos = getDefaultAnnotations();
-			String explain = "Provides Input For Rule. The relation "+r1_label+" "+o_label+" "+r2_label+" was inferred because:\n "+
-					"reaction1 has an output that is an input of reaction 2. ";
-			annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(explain)));
-			this.addRefBackedObjectPropertyAssertion(r1, o, r2, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);
-			applyAnnotatedTripleRemover(r1.getIRI(), causally_upstream_of.getIRI(), r2.getIRI());
-		}	
-		r.rule_hitcount.put(provides_input_rule, provides_input_count);
-		r.rule_pathways.put(provides_input_rule, provides_input_pathways);
-		qrunner = new QRunner(go_cam_ont); 
-		return r;
-	}
-
-	private RuleResults inferProvidesInputRemoveCausalRelation(String model_id, RuleResults r) {
-		/*
-		 * Searches for inferred input reaction pairs to delete causally_upstream_of relation added earlier
-		 */
-		String provides_input_rule = "Provides Input For Rule";
-		Integer provides_input_count = r.checkInitCount(provides_input_rule, r);
-		Set<String> provides_input_pathways = r.checkInitPathways(provides_input_rule, r);
-
-		Set<InferredRegulator> provides_input = qrunner.getInferredInputProviders();
-		provides_input_count+=provides_input.size();
-		for(InferredRegulator ir : provides_input) {
-			provides_input_pathways.add(ir.pathway_uri);
-			//create ?reaction2 obo:RO_0002333 ?input
-			OWLNamedIndividual r1 = this.makeAnnotatedIndividual(ir.reaction1_uri);
-			OWLNamedIndividual r2 = this.makeAnnotatedIndividual(ir.reaction2_uri);
+			//Check if rxns are already connected via common input/output instance
+			if (!ir.input_instance_uri.equals(ir.output_instance_uri)) {
+				OWLObjectProperty o = df.getOWLObjectProperty(IRI.create(ir.prop_uri));
+				String r1_label = "'"+this.getaLabel(r1)+"'";
+				String r2_label = "'"+this.getaLabel(r2)+"'";
+				String o_label = "'"+this.getaLabel(o)+"'";
+				Set<OWLAnnotation> annos = getDefaultAnnotations();
+				String explain = "Provides Input For Rule. The relation "+r1_label+" "+o_label+" "+r2_label+" was inferred because:\n "+
+						"reaction1 has an output that is an input of reaction 2. ";
+				annos.add(df.getOWLAnnotation(rdfs_comment, df.getOWLLiteral(explain)));
+				this.addRefBackedObjectPropertyAssertion(r1, o, r2, Collections.singleton(model_id), GoCAM.eco_inferred_auto, default_namespace_prefix, annos, model_id);
+			}
 			applyAnnotatedTripleRemover(r1.getIRI(), causally_upstream_of.getIRI(), r2.getIRI());
 		}	
 		r.rule_hitcount.put(provides_input_rule, provides_input_count);

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/QRunner.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/QRunner.java
@@ -440,6 +440,18 @@ select ?reaction2 obo:RO_0002333 ?input   # for update
 		}
 	}
 	
+	class InferredInputRegulator extends InferredRegulator {
+		String output_instance_uri;
+		String input_instance_uri;
+		InferredInputRegulator(String r1_uri, String p_uri, String r2_uri, String pathway, String entity,
+				String entity_type, String output_uri, String input_uri) {
+			super(r1_uri, p_uri, r2_uri, pathway, entity, entity_type);
+			output_instance_uri = output_uri;
+			input_instance_uri = input_uri;
+		}
+		
+	}
+	
 	Set<InferredRegulator> getInferredRegulatorsQ1() {
 		Set<InferredRegulator> ir = new HashSet<InferredRegulator>();
 		String query = null;
@@ -587,8 +599,8 @@ select ?reaction2 obo:RO_0002333 ?input   # for update
 		return irs;
 	}
 	
-	Set<InferredRegulator> getInferredInputProviders() {
-		Set<InferredRegulator> ir = new HashSet<InferredRegulator>();
+	Set<InferredInputRegulator> getInferredInputProviders() {
+		Set<InferredInputRegulator> ir = new HashSet<InferredInputRegulator>();
 		String query = null;
 		try {		
 			query = IOUtils.toString(QRunner.class.getResourceAsStream("query2update_provides_input_for.rq"), StandardCharsets.UTF_8);
@@ -602,12 +614,14 @@ select ?reaction2 obo:RO_0002333 ?input   # for update
 			Resource reaction1 = qs.getResource("reaction1"); 
 			Resource reaction2 = qs.getResource("reaction2"); 
 			Resource pathway = qs.getResource("pathway");
+			Resource r1output = qs.getResource("r1output");
+			Resource r2input = qs.getResource("reaction2input");
 			//reaction1  provides_input_for reaction 2
 			String pathway_uri = "";
 			if(pathway!=null) {
 				pathway_uri = pathway.getURI();
 			}
-			ir.add(new InferredRegulator(reaction1.getURI(), GoCAM.provides_direct_input_for.getIRI().toString(), reaction2.getURI(), pathway_uri, "", ""));
+			ir.add(new InferredInputRegulator(reaction1.getURI(), GoCAM.provides_direct_input_for.getIRI().toString(), reaction2.getURI(), pathway_uri, "", "", r1output.getURI(), r2input.getURI()));
 		}
 		qe.close();
 		return ir;

--- a/exchange/src/main/resources/org/geneontology/gocam/exchange/query2update_provides_input_for.rq
+++ b/exchange/src/main/resources/org/geneontology/gocam/exchange/query2update_provides_input_for.rq
@@ -10,7 +10,7 @@ prefix skos: <http://www.w3.org/2004/02/skos/core#>
 #and reaction1 causally_upstream_of reaction2 
 #then reaction1 directly_positively_regulates reaction2
 
-select distinct ?reaction2 ?reaction1 ?reaction2inputLabel ?reaction2Label ?reaction1Label ?pathway 
+select distinct ?reaction2 ?reaction1 ?reaction2inputLabel ?reaction2Label ?reaction1Label ?pathway ?r1output ?reaction2input
 where { 
   # limit to relationships in the same Pathway
   # promiscuous molecules make this important to avoid explosions


### PR DESCRIPTION
For #276.

This adds a check to `inferProvidesInput` to only replace the existing `causally_upstream_of` relation with `provides_input_for` if the matched input and output instance IRIs are not equal, aka not the same individual:
https://github.com/geneontology/pathways2GO/blob/35f360cc43ffdbbaa01a0d10eacb78c57e1daf66/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java#L1386
In either case, the existing `causally_upstream_of` relation will still be removed:
https://github.com/geneontology/pathways2GO/blob/35f360cc43ffdbbaa01a0d10eacb78c57e1daf66/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java#L1397