### PR TITLE
Connect branched and cyclical YeastPathways models

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -1335,7 +1335,11 @@ public class BioPaxtoGO {
 							// Gotta make these locations specific to rxn ID for do_not_join classes
 							input_location = entity_id;
 						} else {
-							input_location = String.join("_", input.getCellularLocation().getTerm());
+							Set<String> in_location_terms = new HashSet<String>();
+							for (String loc_term : input.getCellularLocation().getTerm()) {
+								in_location_terms.add(loc_term.replace(" ", "_"));
+							}
+							input_location = String.join("_", in_location_terms);
 						}
 						if(entityStrategy.equals(EntityStrategy.YeastCyc) && !small_mol_do_not_join_ids.contains(input_id)){
 							// Try to reuse previous rxn's output instance
@@ -1379,7 +1383,11 @@ public class BioPaxtoGO {
 							// Gotta make these locations specific to rxn ID for do_not_join classes
 							output_location = entity_id;
 						} else {
-							output_location = String.join("_", output.getCellularLocation().getTerm());
+							Set<String> out_location_terms = new HashSet<String>();
+							for (String loc_term : output.getCellularLocation().getTerm()) {
+								out_location_terms.add(loc_term.replace(" ", "_"));
+							}
+							output_location = String.join("_", out_location_terms);
 						}
 						o_iri = GoCAM.makeGoCamifiedIRI(null, output_id+"_"+output_location);
 						OWLNamedIndividual output_entity = go_cam.df.getOWLNamedIndividual(o_iri);

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -1331,7 +1331,7 @@ public class BioPaxtoGO {
 							input_id = UUID.randomUUID().toString();
 						}
 						String input_location = null;
-						if (small_mol_do_not_join_ids.contains(input_id) || input.getCellularLocation() == null) {
+						if (small_mol_do_not_join_ids.contains(input_id) || input.getCellularLocation() == null || entityStrategy.equals(EntityStrategy.REACTO)) {
 							// Gotta make these locations specific to rxn ID for do_not_join classes
 							input_location = entity_id;
 						} else {
@@ -1379,7 +1379,7 @@ public class BioPaxtoGO {
 							output_id = UUID.randomUUID().toString();
 						}
 						String output_location = null;
-						if (small_mol_do_not_join_ids.contains(output_id) || output.getCellularLocation() == null) {
+						if (small_mol_do_not_join_ids.contains(output_id) || output.getCellularLocation() == null || entityStrategy.equals(EntityStrategy.REACTO)) {
 							// Gotta make these locations specific to rxn ID for do_not_join classes
 							output_location = entity_id;
 						} else {

--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -1330,6 +1330,13 @@ public class BioPaxtoGO {
 						if(input_id==null){ //failed to find a chebi reference
 							input_id = UUID.randomUUID().toString();
 						}
+						String input_location = null;
+						if (small_mol_do_not_join_ids.contains(input_id) || input.getCellularLocation() == null) {
+							// Gotta make these locations specific to rxn ID for do_not_join classes
+							input_location = entity_id;
+						} else {
+							input_location = String.join("_", input.getCellularLocation().getTerm());
+						}
 						if(entityStrategy.equals(EntityStrategy.YeastCyc) && !small_mol_do_not_join_ids.contains(input_id)){
 							// Try to reuse previous rxn's output instance
 							for(PathwayStep previous_step : previous_steps) {
@@ -1342,15 +1349,13 @@ public class BioPaxtoGO {
 									previous_outputs = reaction.getRight();
 								}
 								if(previous_outputs.contains(input)) { // We can reuse this previous rxn's output instance
-									String prev_entity_id = getEntityReferenceId(reaction);
-									i_iri = GoCAM.makeGoCamifiedIRI(null, input_id+"_"+prev_entity_id);
+									i_iri = GoCAM.makeGoCamifiedIRI(null, input_id+"_"+input_location);
 									input_entity = go_cam.df.getOWLNamedIndividual(i_iri);
-									break;
 								}
 							}
 						}
 						if(i_iri==null){
-							i_iri = GoCAM.makeGoCamifiedIRI(null, input_id+"_"+entity_id);
+							i_iri = GoCAM.makeGoCamifiedIRI(null, input_id+"_"+input_location);
 							input_entity = go_cam.df.getOWLNamedIndividual(i_iri);
 							defineReactionEntity(go_cam, input, i_iri, true, model_id, root_pathway_iri);
 						}
@@ -1369,7 +1374,14 @@ public class BioPaxtoGO {
 						if(output_id==null) {
 							output_id = UUID.randomUUID().toString();
 						}
-						o_iri = GoCAM.makeGoCamifiedIRI(null, output_id+"_"+entity_id);
+						String output_location = null;
+						if (small_mol_do_not_join_ids.contains(output_id) || output.getCellularLocation() == null) {
+							// Gotta make these locations specific to rxn ID for do_not_join classes
+							output_location = entity_id;
+						} else {
+							output_location = String.join("_", output.getCellularLocation().getTerm());
+						}
+						o_iri = GoCAM.makeGoCamifiedIRI(null, output_id+"_"+output_location);
 						OWLNamedIndividual output_entity = go_cam.df.getOWLNamedIndividual(o_iri);
 						defineReactionEntity(go_cam, output, o_iri, true, model_id, root_pathway_iri);
 						go_cam.addRefBackedObjectPropertyAssertion(e, GoCAM.has_output, output_entity, dbids, GoCAM.eco_imported_auto,  default_namespace_prefix, go_cam.getDefaultAnnotations(), model_id);

--- a/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
+++ b/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
@@ -1013,20 +1013,31 @@ BP has_part R
 		System.out.println("Done testing regulates via output enables");
 	}
 	
+	//gomodel:R-HSA-4641262/R-HSA-201677 / RO:0002413 / gomodel:R-HSA-4641262/R-HSA-201691
+	// #inferProvidesInput	
+	/**
+	 * Test method for {@link org.geneontology.gocam.exchange.GoCAM#inferProvidesInput}.
+	 * Use pathway R-HSA-4641262 , reaction1 = R-HSA-201677 reaction2 = R-HSA-201691
+	 * Relation should be RO:0002413 directly positive regulates
+	 * Phosphorylation of LRP5/6 cytoplasmic domain by membrane-associated GSK3beta
+	 * Phosphorylation of LRP5/6 cytoplasmic domain by CSNKI
+	 * 	https://reactome.org/content/detail/R-HSA-4641262 
+	 * Compare to http://noctua-dev.berkeleybop.org/editor/graph/gomodel:R-HSA-4641262
+	 * 
+	 * Also an active site detection test
+	 */
 	@Test
-	public final void testSharedIntermediateInputs() {
+	public final void testInferProvidesInput() {
 		System.out.println("Testing provides input");
 		TupleQueryResult result = null;
 		try {
-			// Check for shared input/output entity instance between rxns
 			result = blaze.runSparqlQuery(
 				"prefix obo: <http://purl.obolibrary.org/obo/> "
 				+ "select ?pathway " + 
 				"where { " + 
 				"VALUES ?reaction1 { <http://model.geneontology.org/R-HSA-201677> } . "+ 
 				"VALUES ?reaction2 { <http://model.geneontology.org/R-HSA-201691> } . "+
-				" ?reaction1 obo:RO_0002234 ?small_mol . " +
-				" ?reaction2 obo:RO_0002233 ?small_mol . "
+				" ?reaction1 obo:RO_0002413 ?reaction2 . "
 				+ "?reaction1 obo:BFO_0000050 ?pathway "+				
 				"}");
 			int n = 0; String pathway = null;
@@ -1048,7 +1059,7 @@ BP has_part R
 				e.printStackTrace();
 			}
 		}
-		System.out.println("Done testing sharing of intermediate small molecules");
+		System.out.println("Done testing regulates via output enables");
 	}
 	
 	@Test

--- a/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
+++ b/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
@@ -1013,31 +1013,20 @@ BP has_part R
 		System.out.println("Done testing regulates via output enables");
 	}
 	
-	//gomodel:R-HSA-4641262/R-HSA-201677 / RO:0002413 / gomodel:R-HSA-4641262/R-HSA-201691
-	// #inferProvidesInput	
-	/**
-	 * Test method for {@link org.geneontology.gocam.exchange.GoCAM#inferProvidesInput}.
-	 * Use pathway R-HSA-4641262 , reaction1 = R-HSA-201677 reaction2 = R-HSA-201691
-	 * Relation should be RO:0002413 directly positive regulates
-	 * Phosphorylation of LRP5/6 cytoplasmic domain by membrane-associated GSK3beta
-	 * Phosphorylation of LRP5/6 cytoplasmic domain by CSNKI
-	 * 	https://reactome.org/content/detail/R-HSA-4641262 
-	 * Compare to http://noctua-dev.berkeleybop.org/editor/graph/gomodel:R-HSA-4641262
-	 * 
-	 * Also an active site detection test
-	 */
 	@Test
-	public final void testInferProvidesInput() {
+	public final void testSharedIntermediateInputs() {
 		System.out.println("Testing provides input");
 		TupleQueryResult result = null;
 		try {
+			// Check for shared input/output entity instance between rxns
 			result = blaze.runSparqlQuery(
 				"prefix obo: <http://purl.obolibrary.org/obo/> "
 				+ "select ?pathway " + 
 				"where { " + 
 				"VALUES ?reaction1 { <http://model.geneontology.org/R-HSA-201677> } . "+ 
 				"VALUES ?reaction2 { <http://model.geneontology.org/R-HSA-201691> } . "+
-				" ?reaction1 obo:RO_0002413 ?reaction2 . "
+				" ?reaction1 obo:RO_0002234 ?small_mol . " +
+				" ?reaction2 obo:RO_0002233 ?small_mol . "
 				+ "?reaction1 obo:BFO_0000050 ?pathway "+				
 				"}");
 			int n = 0; String pathway = null;
@@ -1059,7 +1048,7 @@ BP has_part R
 				e.printStackTrace();
 			}
 		}
-		System.out.println("Done testing regulates via output enables");
+		System.out.println("Done testing sharing of intermediate small molecules");
 	}
 	
 	@Test


### PR DESCRIPTION
This addresses #285 by keeping only one instance of location-specific small molecule classes. For example, the instance ID `gomodel:CHEBI_16975_cytosol` (1-acyl-sn-glycerol 3-phosphate) is an output of two reactions and an input of one, which effectively combines two branches of the pathway [PWY3O-6635](https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?type=NIL&object=PWY3O-6635&redirect=T) superpathway of phosphatidate biosynthesis.

Noting that this logic is still (for now) specific to YeastPathways with Reactome explicitly excluded. I will submit a separate, isolated PR to remove this Reactome exclusion when we're OK to do that.