### PR TITLE
Do not overwrite pathwayComponentOf of reactions

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/BioPaxtoGO.java
@@ -748,10 +748,11 @@ public class BioPaxtoGO {
 	}
 	
 	private boolean processesAreInSamePathway(Process proc_a, Process proc_b) {
-		Set<Pathway> event_pathways = proc_a.getPathwayComponentOf();
+		Set<Pathway> common_pathways = new HashSet<Pathway>();
+		common_pathways.addAll(proc_a.getPathwayComponentOf());
 		Set<Pathway> prev_event_pathways = proc_b.getPathwayComponentOf();
-		event_pathways.retainAll(prev_event_pathways);
-		if(event_pathways.size()>0) {
+		common_pathways.retainAll(prev_event_pathways);
+		if(common_pathways.size()>0) {
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
For #308.

Fixes a bug introduced in #348 that occasionally removes a connection from a BiochemicalReaction to its Pathway (`pathwayComponentOf`). More details of the cause are in https://github.com/geneontology/pathways2GO/issues/308#issuecomment-3256343788.