### PR TITLE
Turn off transporter activity inference

### DIFF
--- a/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
+++ b/exchange/src/main/java/org/geneontology/gocam/exchange/GoCAM.java
@@ -971,8 +971,8 @@ final long counterValue = instanceCounter.getAndIncrement();
 
 		RuleResults r = new RuleResults();
 		//NOTE that the order these are run matters.
-		logger.debug("running transport process inference");
-		r = inferTransportProcess(model_id, r, tbox_qrunner);	//must be run before occurs_in and before deleteLocations	 
+//		logger.debug("running transport process inference");
+//		r = inferTransportProcess(model_id, r, tbox_qrunner);	//must be run before occurs_in and before deleteLocations	 
 		logger.debug("infering molecular function if enablers present");
 		r = inferMolecularFunctionFromEnablers(model_id, r, tbox_qrunner);
 		logger.debug("inferring occurs in from entity locations");

--- a/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
+++ b/exchange/src/test/java/org/geneontology/gocam/exchange/BioPaxtoGOTest.java
@@ -584,7 +584,8 @@ public class BioPaxtoGOTest {
 	/**
 	 * nice example: R-HSA-997272 Reactome:unexpanded:Inhibition of voltage gated Ca2+ channels via Gbeta/gamma subunits
 	 */
-	@Test
+	// Turning off as part of https://github.com/geneontology/pathways2GO/issues/345
+//	@Test
 	public final void testInferLocalizationProcess() {
 		System.out.println("Testing localization inference");
 		TupleQueryResult result = null;
@@ -639,7 +640,8 @@ public class BioPaxtoGOTest {
 	 * Beta-catenin translocates to the nucleus
 	 * 	reaction uri http://model.geneontology.org/R-HSA-201681/R-HSA-201669 
 	 */
-	@Test
+	// Turning off as part of https://github.com/geneontology/pathways2GO/issues/345
+//	@Test
 	public final void testInferProteinLocalizationProcess() {
 		System.out.println("Testing localization inference");
 		TupleQueryResult result = null;


### PR DESCRIPTION
For #345.

Simply stops inferring "transporter activity" and start/end locations for transport activities.